### PR TITLE
Leaves fix

### DIFF
--- a/src/main/java/net/tropicraft/block/BlockBundle.java
+++ b/src/main/java/net/tropicraft/block/BlockBundle.java
@@ -1,5 +1,6 @@
 package net.tropicraft.block;
 
+import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
@@ -15,7 +16,7 @@ public class BlockBundle extends BlockTropicraft {
 	private IIcon side;
 	
 	public BlockBundle(String name) {
-		super();
+		super(Material.plants); // closest to thatch
 		this.setBlockTextureName(name);
 		this.setBlockName(name);
 	}

--- a/src/main/java/net/tropicraft/block/BlockRainforestLeaves.java
+++ b/src/main/java/net/tropicraft/block/BlockRainforestLeaves.java
@@ -81,8 +81,12 @@ public class BlockRainforestLeaves extends BlockLeaves {
         list.add(new ItemStack(item, 1, 2));	// Fruit
     }
     
+    /*
+     * The Server only annotation made the leaves drop birch saplings in offline worlds.
+     * So I disabled it.
+     */
     @Override
-    @SideOnly(Side.SERVER)
+    //@SideOnly(Side.SERVER)
     public Item getItemDropped(int metadata, Random random, int j) {
     	if (metadata < 2)
     		return Item.getItemFromBlock(TCBlockRegistry.saplings);

--- a/src/main/java/net/tropicraft/block/BlockTropicraftOre.java
+++ b/src/main/java/net/tropicraft/block/BlockTropicraftOre.java
@@ -2,6 +2,7 @@ package net.tropicraft.block;
 
 import java.util.Random;
 
+import net.minecraft.block.material.Material;
 import net.minecraft.item.Item;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
@@ -14,7 +15,7 @@ public class BlockTropicraftOre extends BlockTropicraft {
     private Random rand = new Random();
     
 	public BlockTropicraftOre() {
-		super();
+		super(Material.rock); // closest to ore
 	}
 	
 	@Override


### PR DESCRIPTION
When breaking a tropicraft leaves block, like fruit leaves or rainforest leaves, birch saplings are dropped, rather than saplings of the actual tropicraft tree. This is a fix for that.