### PR TITLE
fixes the logs so that there's only one log type per tree

### DIFF
--- a/src/main/java/net/tropicraft/block/BlockTropicraftLog.java
+++ b/src/main/java/net/tropicraft/block/BlockTropicraftLog.java
@@ -169,6 +169,13 @@ public class BlockTropicraftLog extends BlockTropicraftMulti {
 		return palmEnd;
 	}
 
+    @Override
+    public int damageDropped (int meta)
+    {
+        // 0 for palm, 1 for mahogany
+        return meta % 2;
+    }
+
 	/**
 	 * Returns the quantity of items to drop on block destruction.
 	 */


### PR DESCRIPTION
Right now, palm and mahogany logs can each occur in two item types, depending
on the orientation of the log block when it's chopped. It can be qite annoying, since the two versions of the log don't stack up. This fixes the problem so that all orientations of palm log blocks drop the same palm log item. Idem for mahogany logs.