### PR TITLE
Improve performance of leaves that are opaque

### DIFF
--- a/src/main/java/net/tropicraft/core/common/block/BlockTropicraftLeaves.java
+++ b/src/main/java/net/tropicraft/core/common/block/BlockTropicraftLeaves.java
@@ -97,13 +97,17 @@ public class BlockTropicraftLeaves extends BlockLeaves implements ITropicraftBlo
 
 	@Override
 	public boolean isOpaqueCube(IBlockState state) {
-		return Blocks.LEAVES.isOpaqueCube(state);
+		return state.getValue(VARIANT).isSolid();
 	}
 
 	@SideOnly(Side.CLIENT)
 	@Override
+	@Deprecated
 	public boolean shouldSideBeRendered(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side) {
-		return Blocks.LEAVES.shouldSideBeRendered(state, world, pos, side);
+		return state.getValue(VARIANT).isSolid() ? 
+				// bit of a hack, break out of encapsulation, assumes stone hasn't been messed with by mods
+				Blocks.STONE.shouldSideBeRendered(state, world, pos, side) : 
+				super.shouldSideBeRendered(state, world, pos, side);
 	}
 
 	/**

--- a/src/main/java/net/tropicraft/core/common/enums/TropicraftLeaves.java
+++ b/src/main/java/net/tropicraft/core/common/enums/TropicraftLeaves.java
@@ -3,14 +3,20 @@ package net.tropicraft.core.common.enums;
 import net.minecraft.util.IStringSerializable;
 
 public enum TropicraftLeaves implements IStringSerializable {
-    MAHOGANY(0), PALM(1), KAPOK(2), FRUIT(3);
+    MAHOGANY(false, 0), PALM(true, 1), KAPOK(true, 2), FRUIT(false, 3);
     
     private static final TropicraftLeaves[] META_LOOKUP = new TropicraftLeaves[values().length];
+    private final boolean solid;
     private final int meta;
     public static final TropicraftLeaves[] VALUES = values();
     
-    private TropicraftLeaves(int meta) {
+    private TropicraftLeaves(boolean solid, int meta) {
+    	this.solid = solid;
     	this.meta = meta;
+    }
+    
+    public boolean isSolid() {
+    	return solid;
     }
     
 	public int getMetadata() {


### PR DESCRIPTION
Kapok and Palm leaves will now cull faces against themselves, reducing the number of rendered sides by quite a bit in large forests.