### PR TITLE
Reduce biome decoration cascading chunk generation

### DIFF
--- a/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorRainforest.java
+++ b/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorRainforest.java
@@ -1,7 +1,5 @@
 package net.tropicraft.core.common.biome.decorators;
 
-import java.util.Random;
-
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -13,6 +11,8 @@ import net.tropicraft.core.common.worldgen.WorldGenTallTree;
 import net.tropicraft.core.common.worldgen.WorldGenTualang;
 import net.tropicraft.core.common.worldgen.WorldGenUndergrowth;
 import net.tropicraft.core.common.worldgen.WorldGenUpTree;
+
+import java.util.Random;
 
 public class BiomeDecoratorRainforest extends BiomeDecoratorTropicraft {
 
@@ -64,36 +64,36 @@ public class BiomeDecoratorRainforest extends BiomeDecoratorTropicraft {
 		}
 		//
 		//		if(rand.nextInt(ALTAR_CHANCE) == 0) {
-		//			new WorldGenForestAltarRuin(world, rand).generate(randCoord(rand, x, 16), 0, randCoord(rand, x, 16));
+		//			new WorldGenForestAltarRuin(world, rand).generate(randDecorationCoord(rand, x, 16), 0, randDecorationCoord(rand, x, 16));
 		//		}
 		//
 		if (rand.nextInt(TALL_TREE_CHANCE) == 0) {
-			i = randCoord(rand, x, 16);
-			k = randCoord(rand, z, 16);
+			i = randDecorationCoord(rand, x, 16);
+			k = randDecorationCoord(rand, z, 16);
 			new WorldGenTallTree(world, rand).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
 		}
 
 		if (rand.nextInt(UP_TREE_CHANCE) == 0) {
-			i = randCoord(rand, x, 16);
-			k = randCoord(rand, z, 16);
+			i = randDecorationCoord(rand, x, 16);
+			k = randDecorationCoord(rand, z, 16);
 			new WorldGenUpTree(world, rand).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));			
 		}
 
 		for (int a = 0; a < SMALL_TUALANG_AMOUNT; a++) {
-			i = randCoord(rand, x, 16);
-			k = randCoord(rand, z, 16);
+			i = randDecorationCoord(rand, x, 16);
+			k = randDecorationCoord(rand, z, 16);
 			new WorldGenTualang(world, rand, 16, 9).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
 		}
 
 		for (int a = 0; a < LARGE_TUALANG_AMOUNT; a++) {
-			i = randCoord(rand, x, 16);
-			k = randCoord(rand, z, 16);
+			i = randDecorationCoord(rand, x, 16);
+			k = randDecorationCoord(rand, z, 16);
 			new WorldGenTualang(world, rand, 25, 11).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
 		}
 
 		for (int a = 0; a < UNDERGROWTH_AMOUNT; a++) {
-			i = randCoord(rand, x, 16);
-			k = randCoord(rand, z, 16);
+			i = randDecorationCoord(rand, x, 16);
+			k = randDecorationCoord(rand, z, 16);
 			new WorldGenUndergrowth(world, rand).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
 		}
 
@@ -111,8 +111,8 @@ public class BiomeDecoratorRainforest extends BiomeDecoratorTropicraft {
 		}
 		//
 		//		for(int a = 0; a < COFFEE_PLANT_AMOUNT; a++) {
-		//			int i = randCoord(rand, x, 16);
-		//			int k = randCoord(rand, z, 16);
+		//			int i = randDecorationCoord(rand, x, 16);
+		//			int k = randDecorationCoord(rand, z, 16);
 		//			new WorldGenCoffeePlant(world, rand).generate(i, getTerrainHeightAt(world, i, k), k);
 		//		}
 	}

--- a/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropicraft.java
+++ b/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropicraft.java
@@ -38,8 +38,8 @@ public class BiomeDecoratorTropicraft extends BiomeDecorator {
 		return 0;
 	}
 
-
 	public final int randDecorationCoord(Random rand, int base, int variance) {
+		// Offset by 8 to ensure coordinate is in center of chunks for decoration so that CCG is avoided
 		return base + rand.nextInt(variance) + 8;
 	}
 }

--- a/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropicraft.java
+++ b/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropicraft.java
@@ -1,13 +1,13 @@
 package net.tropicraft.core.common.biome.decorators;
 
-import java.util.Random;
-
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeDecorator;
+
+import java.util.Random;
 
 public class BiomeDecoratorTropicraft extends BiomeDecorator {
 
@@ -39,7 +39,7 @@ public class BiomeDecoratorTropicraft extends BiomeDecorator {
 	}
 
 
-	public final int randCoord(Random rand, int base, int variance) {
-		return base + rand.nextInt(variance);
+	public final int randDecorationCoord(Random rand, int base, int variance) {
+		return base + rand.nextInt(variance) + 8;
 	}
 }

--- a/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropics.java
+++ b/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropics.java
@@ -45,43 +45,43 @@ public class BiomeDecoratorTropics extends BiomeDecoratorTropicraft {
 		}
 
 		if (ConfigGenRates.BAMBOO_CHANCE != 0 && rand.nextInt(ConfigGenRates.BAMBOO_CHANCE) == 0) {
-			i = randCoord(rand, chunkPos.getX(), 16);
-			k = randCoord(rand, chunkPos.getZ(), 16);
+			i = randDecorationCoord(rand, chunkPos.getX(), 16);
+			k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 			new WorldGenBamboo(world, rand).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
 		}
 
 		if (ConfigGenRates.NORMAL_PALM_CHANCE != 0 && rand.nextInt(ConfigGenRates.NORMAL_PALM_CHANCE) == 0) {
-			i = randCoord(rand, chunkPos.getX(), 16);
-			k = randCoord(rand, chunkPos.getZ(), 16);
+			i = randDecorationCoord(rand, chunkPos.getX(), 16);
+			k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 			new WorldGenNormalPalms(world, rand).generate(new BlockPos(i, this.getTerrainHeightAt(world, i, k), k));
 		}
 
 		if (ConfigGenRates.CURVED_PALM_CHANCE != 0 && rand.nextInt(ConfigGenRates.CURVED_PALM_CHANCE) == 0) {
-			i = randCoord(rand, chunkPos.getX(), 16);
-			k = randCoord(rand, chunkPos.getZ(), 16);
+			i = randDecorationCoord(rand, chunkPos.getX(), 16);
+			k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 			new WorldGenCurvedPalms(world, rand).generate(new BlockPos(i, this.getTerrainHeightAt(world, i, k), k));
 		}
 
 		if (ConfigGenRates.EIH_CHANCE != 0 && rand.nextInt(ConfigGenRates.EIH_CHANCE) == 0) {
-			i = randCoord(rand, chunkPos.getX(), 16);
-			k = randCoord(rand, chunkPos.getZ(), 16);
+			i = randDecorationCoord(rand, chunkPos.getX(), 16);
+			k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 			new WorldGenEIH(world, rand).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
 		}
 
-		i = randCoord(rand, chunkPos.getX(), 16);
-		k = randCoord(rand, chunkPos.getZ(), 16);
+		i = randDecorationCoord(rand, chunkPos.getX(), 16);
+		k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 		new WorldGenTropicalFlowers(world, rand, BlockRegistry.flowers).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
 
 		if (ConfigGenRates.LARGE_PALM_CHANCE != 0 && rand.nextInt(ConfigGenRates.LARGE_PALM_CHANCE) == 0) {
-			i = randCoord(rand, chunkPos.getX(), 16);
-			k = randCoord(rand, chunkPos.getZ(), 16);
+			i = randDecorationCoord(rand, chunkPos.getX(), 16);
+			k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 			new WorldGenLargePalmTrees(world, rand).generate(world, rand, new BlockPos(i, this.getTerrainHeightAt(world, i, k), k));
 		}
 
 		if (ConfigGenRates.FRUIT_TREE_CHANCE != 0 && rand.nextInt(ConfigGenRates.FRUIT_TREE_CHANCE) == 0) {
 			int treeType = new Random((long)(chunkPos.getX() >> 2) << 32 | (long)(chunkPos.getZ() >> 2)).nextInt(4);
-			i = randCoord(rand, chunkPos.getX(), 16);
-			k = randCoord(rand, chunkPos.getZ(), 16);
+			i = randDecorationCoord(rand, chunkPos.getX(), 16);
+			k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 			new WorldGenFruitTrees(world, rand, treeType).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
 		}
 
@@ -100,31 +100,31 @@ public class BiomeDecoratorTropics extends BiomeDecoratorTropicraft {
 		
 		// Pineapples
 		if (ConfigGenRates.TALL_FLOWERS_CHANCE != 0 && rand.nextInt(ConfigGenRates.TALL_FLOWERS_CHANCE) == 0) {
-			i = randCoord(rand, chunkPos.getX(), 16);
+			i = randDecorationCoord(rand, chunkPos.getX(), 16);
 	        int y = getTerrainHeightAt(world, i, k);
-	        k = randCoord(rand, chunkPos.getZ(), 16);
+	        k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 			BlockPos pos = new BlockPos(i, y, k);
 			(new WorldGenTallFlower(world, rand, BlockRegistry.pineapple.getDefaultState())).generate(pos);
 		}
 		
 		// Irises
 		if (ConfigGenRates.TALL_FLOWERS_CHANCE != 0 && rand.nextInt(ConfigGenRates.TALL_FLOWERS_CHANCE) == 0) {
-			i = randCoord(rand, chunkPos.getX(), 16);
+			i = randDecorationCoord(rand, chunkPos.getX(), 16);
 	        int y = getTerrainHeightAt(world, i, k);
-	        k = randCoord(rand, chunkPos.getZ(), 16);
+	        k = randDecorationCoord(rand, chunkPos.getZ(), 16);
 			BlockPos pos = new BlockPos(i, y, k);
 			(new WorldGenTallFlower(world, rand, BlockRegistry.iris.getDefaultState())).generate(pos);
 		}
 
 		//		if(rand.nextInt(TREASURE_CHANCE) == 0) {
-		//			int i = randCoord(rand, x, 16);
-		//			int k = randCoord(rand, z, 16);
+		//			int i = randDecorationCoord(rand, x, 16);
+		//			int k = randDecorationCoord(rand, z, 16);
 		//			new WorldGenTropicsTreasure(world, rand).generate(i, getTerrainHeightAt(world, i, k), k);
 		//		}
 
         //
         //      for(int a = 0; a < ConfigGenRates.WATERFALL_AMOUNT; a++) {
-        //          new WorldGenWaterfall(world, rand).generate(randCoord(rand, x, 16), WorldProviderTropicraft.MID_HEIGHT + rand.nextInt(WorldProviderTropicraft.INTER_HEIGHT), randCoord(rand, z, 16));
+        //          new WorldGenWaterfall(world, rand).generate(randDecorationCoord(rand, x, 16), WorldProviderTropicraft.MID_HEIGHT + rand.nextInt(WorldProviderTropicraft.INTER_HEIGHT), randDecorationCoord(rand, z, 16));
         //      }
 	}
 

--- a/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropicsBeach.java
+++ b/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropicsBeach.java
@@ -1,7 +1,5 @@
 package net.tropicraft.core.common.biome.decorators;
 
-import java.util.Random;
-
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -11,6 +9,8 @@ import net.tropicraft.core.common.worldgen.WorldGenCurvedPalms;
 import net.tropicraft.core.common.worldgen.WorldGenLargePalmTrees;
 import net.tropicraft.core.common.worldgen.WorldGenNormalPalms;
 import net.tropicraft.core.common.worldgen.WorldGenTropicsTreasure;
+
+import java.util.Random;
 
 public class BiomeDecoratorTropicsBeach extends BiomeDecoratorTropicraft {
 
@@ -37,34 +37,34 @@ public class BiomeDecoratorTropicsBeach extends BiomeDecoratorTropicraft {
         int k = 0;
 
         if (ConfigGenRates.NORMAL_PALM_CHANCE != 0 && rand.nextInt(ConfigGenRates.NORMAL_PALM_CHANCE) == 0) {
-            i = randCoord(rand, chunkPos.getX(), 16);
-            k = randCoord(rand, chunkPos.getZ(), 16);
+            i = randDecorationCoord(rand, chunkPos.getX(), 16);
+            k = randDecorationCoord(rand, chunkPos.getZ(), 16);
             new WorldGenNormalPalms(world, rand).generate(new BlockPos(i, this.getTerrainHeightAt(world, i, k), k));
         }
 
         if (ConfigGenRates.CURVED_PALM_CHANCE != 0 && rand.nextInt(ConfigGenRates.CURVED_PALM_CHANCE) == 0) {
-            i = randCoord(rand, chunkPos.getX(), 16);
-            k = randCoord(rand, chunkPos.getZ(), 16);
+            i = randDecorationCoord(rand, chunkPos.getX(), 16);
+            k = randDecorationCoord(rand, chunkPos.getZ(), 16);
             new WorldGenCurvedPalms(world, rand).generate(new BlockPos(i, this.getTerrainHeightAt(world, i, k), k));
         }
 
         if (ConfigGenRates.LARGE_PALM_CHANCE != 0 && rand.nextInt(ConfigGenRates.LARGE_PALM_CHANCE) == 0) {
-            i = randCoord(rand, chunkPos.getX(), 16);
-            k = randCoord(rand, chunkPos.getZ(), 16);
+            i = randDecorationCoord(rand, chunkPos.getX(), 16);
+            k = randDecorationCoord(rand, chunkPos.getZ(), 16);
             new WorldGenLargePalmTrees(world, rand).generate(world, rand, new BlockPos(i, this.getTerrainHeightAt(world, i, k), k));
         }
 
         if(rand.nextInt(TREASURE_CHANCE) == 0) {
-            i = randCoord(rand, chunkPos.getX(), 16);
-            k = randCoord(rand, chunkPos.getZ(), 16);
+            i = randDecorationCoord(rand, chunkPos.getX(), 16);
+            k = randDecorationCoord(rand, chunkPos.getZ(), 16);
             new WorldGenTropicsTreasure(world, rand).generate(world, rand, new BlockPos(i, getTerrainHeightAt(world, i, k), k));
         }
         //		
         //		if(rand.nextInt(VILLAGE_CHANCE) == 0) {
         //			boolean success = false;
         //			for (int ii = 0; ii < 3 && !success; ii++) {
-        //				int i = randCoord(rand, x, 16);
-        //				int k = randCoord(rand, z, 16);
+        //				int i = randDecorationCoord(rand, x, 16);
+        //				int k = randDecorationCoord(rand, z, 16);
         //				int y = world.getTopSolidOrLiquidBlock(i, k);
         //				if (y < WorldProviderTropicraft.MID_HEIGHT) y = WorldProviderTropicraft.MID_HEIGHT+1;
         //				success = TownKoaVillageGenHelper.hookTryGenVillage(new ChunkCoordinates(i, getTerrainHeightAt(world, i, k), k), world);

--- a/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropicsOcean.java
+++ b/src/main/java/net/tropicraft/core/common/biome/decorators/BiomeDecoratorTropicsOcean.java
@@ -1,7 +1,5 @@
 package net.tropicraft.core.common.biome.decorators;
 
-import java.util.Random;
-
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -16,6 +14,8 @@ import net.tropicraft.core.common.worldgen.WorldGenCoral;
 import net.tropicraft.core.common.worldgen.WorldGenSurfaceClump;
 import net.tropicraft.core.common.worldgen.WorldGenTropicsTreasure;
 import net.tropicraft.core.registry.BlockRegistry;
+
+import java.util.Random;
 
 public class BiomeDecoratorTropicsOcean extends BiomeDecoratorTropicraft {
 
@@ -88,28 +88,28 @@ public class BiomeDecoratorTropicsOcean extends BiomeDecoratorTropicraft {
         coralReefGen.generate(world, rand, chunkPos);
         seaweedGen.generate(world, rand, chunkPos);
         //        if (rand.nextInt(5) == 0) {
-        //            int x = randCoord(rand, chunkPos.getX(), 16) + 8;
-        //            int z = randCoord(rand, chunkPos.getZ(), 16) + 8;
+        //            int x = randDecorationCoord(rand, chunkPos.getX(), 16) + 8;
+        //            int z = randDecorationCoord(rand, chunkPos.getZ(), 16) + 8;
         //            BlockPos pos = new BlockPos(x, 0, z);
         //            new WorldGenCoral().generate(world, rand, pos);
         //        }
         //        
         //        if (rand.nextInt(8) == 0) {
-        //            int x = randCoord(rand, chunkPos.getX(), 16) + 8;
-        //            int z = randCoord(rand, chunkPos.getZ(), 16) + 8;
+        //            int x = randDecorationCoord(rand, chunkPos.getX(), 16) + 8;
+        //            int z = randDecorationCoord(rand, chunkPos.getZ(), 16) + 8;
         //            BlockPos pos = new BlockPos(x, 0, z);
         //            new WorldGenSeaweed().generate(world, rand, pos);
         //        }
 
         //        if (ConfigGenRates.SHIPWRECK_CHANCE != 0 /*&& rand.nextInt(ConfigGenRates.SHIPWRECK_CHANCE) == 0*/) {
-        //            int i = randCoord(rand, chunkPos.getX(), 16);
-        //            int k = randCoord(rand, chunkPos.getZ(), 16);
+        //            int i = randDecorationCoord(rand, chunkPos.getX(), 16);
+        //            int k = randDecorationCoord(rand, chunkPos.getZ(), 16);
         //            new WorldGenSunkenShip(world, rand).generate(new BlockPos(i, getTerrainHeightAt(world, i, k), k));
         //        }
 
         if(rand.nextInt(TREASURE_CHANCE) == 0) {
-            int i = randCoord(rand, chunkPos.getX(), 16);
-            int k = randCoord(rand, chunkPos.getZ(), 16);
+            int i = randDecorationCoord(rand, chunkPos.getX(), 16);
+            int k = randDecorationCoord(rand, chunkPos.getZ(), 16);
             new WorldGenTropicsTreasure(world, rand).generate(world, rand, new BlockPos(i, getTerrainHeightAt(world, i, k), k));
         }
     }


### PR DESCRIPTION
This PR reduces cascading chunk generation for decorators by updating the `randCoord` function in `BiomeDecoratorTropicraft` to offset by 8, the chunk center.
The name was also updated to `randDecorationCoord` to clarify that this is not just any random coordinate, it's offset by the chunk center.

Before: https://i.imgur.com/4jOTOUQ.png
After: https://i.imgur.com/aG0NFck.png