### PR TITLE
Convert to block coords before checking biome (fixes #269)

### DIFF
--- a/src/main/java/net/tropicraft/core/common/worldgen/overworld/TCWorldGenerator.java
+++ b/src/main/java/net/tropicraft/core/common/worldgen/overworld/TCWorldGenerator.java
@@ -43,13 +43,13 @@ public class TCWorldGenerator implements IWorldGenerator {
      * @param chunkZ chunkZ
      */
     public void generateSurface(World world, Random random, int chunkX, int chunkZ) {
+        // Convert to block coords rather than chunk coords
+        chunkX *= 16;
+        chunkZ *= 16;
+        
     	Biome biome = world.getBiome(new BlockPos(chunkX, 0, chunkZ));
 
         if (TropicsConfigs.genOverworld) {
-            // Convert to block coords rather than chunk coords
-            chunkX *= 16;
-            chunkZ *= 16;
-
             if (world.provider.getDimension() == 0 && world.getWorldType() != WorldType.FLAT) {
                 int k = chunkX + random.nextInt(16) + 8;
                 int l = random.nextInt(62) + 64;


### PR DESCRIPTION
When obtaining the biome of the chunk's origin, chunk coordinates are used rather than block coordinates, when `getBiome` expects block coordinates. This PR moves the `*= 16` of chunkX and chunkZ to before `getBiome` is called, so it is in block coordinates, therefore fixing several biome checks in world generation.