### PR TITLE
Commands for OPs to save and reset the Survive The Tide minigame map

### DIFF
--- a/src/main/java/net/tropicraft/Tropicraft.java
+++ b/src/main/java/net/tropicraft/Tropicraft.java
@@ -210,6 +210,8 @@ public class Tropicraft {
         CommandReloadConfig.register(event.getServer().getCommandManager().getDispatcher());
         CommandDonation.register(event.getServer().getCommandManager().getDispatcher());
         CommandAddConfigIceberg.register(event.getServer().getCommandManager().getDispatcher());
+        CommandResetIsland.register(event.getServer().getCommandManager().getDispatcher());
+        CommandSaveIsland.register(event.getServer().getCommandManager().getDispatcher());
     }
 
     private void onServerStopping(final FMLServerStoppingEvent event) {

--- a/src/main/java/net/tropicraft/core/common/command/minigames/CommandResetIsland.java
+++ b/src/main/java/net/tropicraft/core/common/command/minigames/CommandResetIsland.java
@@ -1,0 +1,64 @@
+package net.tropicraft.core.common.command.minigames;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.command.CommandSource;
+import net.minecraft.entity.Entity;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.DimensionManager;
+import net.tropicraft.core.common.dimension.TropicraftWorldUtils;
+import net.tropicraft.core.common.minigames.definitions.survive_the_tide.SurviveTheTideMinigameDefinition;
+
+import static net.minecraft.command.Commands.literal;
+
+public class CommandResetIsland {
+	public static void register(final CommandDispatcher<CommandSource> dispatcher) {
+		dispatcher.register(
+			literal("minigame")
+			.then(literal("resetIsland").requires(s -> s.hasPermissionLevel(2))
+			.executes(c -> {
+				Entity entity = c.getSource().getEntity();
+
+				if (entity != null && entity.getServer() != null) {
+					ServerWorld world = DimensionManager.getWorld(entity.getServer(), TropicraftWorldUtils.SURVIVE_THE_TIDE_DIMENSION, false, false);
+
+					if (world != null) {
+						if (world.getPlayers().size() > 0) {
+							c.getSource().sendFeedback(new StringTextComponent("FAILURE: Cannot reset the Survive The Tide dimension while" +
+									" players are still in there. Please remove all players from the dimension first.").applyTextStyle(TextFormatting.RED), true);
+						} else {
+							DimensionManager.unloadWorld(world);
+							c.getSource().sendFeedback(new StringTextComponent("FAILURE: Cannot reset the Survive The Tide dimension while" +
+									" it is still loaded. Begun unloading, please try again in a few seconds.").applyTextStyle(TextFormatting.RED), true);
+						}
+
+						return 0;
+					}
+
+					CompoundNBT data = entity.getPersistentData();
+					if (data.contains("hasConfirmedResetIsland")) {
+						data.remove("hasConfirmedResetIsland");
+
+						SurviveTheTideMinigameDefinition.fetchBaseMap(entity.getServer());
+
+						c.getSource().sendFeedback(new StringTextComponent("Reset island back to saved state!")
+								.applyTextStyle(TextFormatting.GREEN), true);
+
+						return 1;
+					} else {
+						data.putBoolean("hasConfirmedResetIsland", true);
+
+						c.getSource().sendFeedback(new StringTextComponent("WARNING: YOU ARE ABOUT TO RESET THE SURVIVE THE TIDE ISLAND." +
+								"This will destroy any unsaved building progress in the dimension (use /minigame saveIsland to save progress)." +
+								" To confirm, please run the command again.").applyTextStyle(TextFormatting.RED), true);
+
+						return 1;
+					}
+				}
+
+				return 0;
+		})));
+	}
+}

--- a/src/main/java/net/tropicraft/core/common/command/minigames/CommandSaveIsland.java
+++ b/src/main/java/net/tropicraft/core/common/command/minigames/CommandSaveIsland.java
@@ -1,0 +1,64 @@
+package net.tropicraft.core.common.command.minigames;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.command.CommandSource;
+import net.minecraft.entity.Entity;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.DimensionManager;
+import net.tropicraft.core.common.dimension.TropicraftWorldUtils;
+import net.tropicraft.core.common.minigames.definitions.survive_the_tide.SurviveTheTideMinigameDefinition;
+
+import static net.minecraft.command.Commands.literal;
+
+public class CommandSaveIsland {
+	public static void register(final CommandDispatcher<CommandSource> dispatcher) {
+		dispatcher.register(
+			literal("minigame")
+			.then(literal("saveIsland").requires(s -> s.hasPermissionLevel(2))
+			.executes(c -> {
+				Entity entity = c.getSource().getEntity();
+
+				if (entity != null && entity.getServer() != null) {
+					ServerWorld world = DimensionManager.getWorld(entity.getServer(), TropicraftWorldUtils.SURVIVE_THE_TIDE_DIMENSION, false, false);
+
+					if (world != null) {
+						if (world.getPlayers().size() > 0) {
+							c.getSource().sendFeedback(new StringTextComponent("FAILURE: Cannot save the Survive The Tide dimension while" +
+									" players are still in there. Please remove all players from the dimension first.").applyTextStyle(TextFormatting.RED), true);
+						} else {
+							DimensionManager.unloadWorld(world);
+							c.getSource().sendFeedback(new StringTextComponent("FAILURE: Cannot save the Survive The Tide dimension while" +
+									" it is still loaded. Begun unloading, please try again in a few seconds.").applyTextStyle(TextFormatting.RED), true);
+						}
+
+						return 0;
+					}
+
+					CompoundNBT data = entity.getPersistentData();
+					if (data.contains("hasConfirmedSaveIsland")) {
+						data.remove("hasConfirmedSaveIsland");
+
+						SurviveTheTideMinigameDefinition.saveBaseMap(entity.getServer());
+
+						c.getSource().sendFeedback(new StringTextComponent("Saved island as a base so it will be used next time the minigame runs!")
+								.applyTextStyle(TextFormatting.GREEN), true);
+
+						return 1;
+					} else {
+						data.putBoolean("hasConfirmedSaveIsland", true);
+
+						c.getSource().sendFeedback(new StringTextComponent("WARNING: YOU ARE ABOUT TO SAVE THE SURVIVE THE TIDE ISLAND." +
+								"This will overwrite the saved base map that is currently used when running the minigame." +
+								" To confirm, please run the command again.").applyTextStyle(TextFormatting.RED), true);
+
+						return 1;
+					}
+				}
+
+				return 0;
+		})));
+	}
+}

--- a/src/main/java/net/tropicraft/core/common/minigames/MinigamePlayerCache.java
+++ b/src/main/java/net/tropicraft/core/common/minigames/MinigamePlayerCache.java
@@ -40,9 +40,7 @@ public class MinigamePlayerCache {
         new FoodStats().write(foodTag);
         player.getFoodStats().read(foodTag);
 
-        for (EffectInstance effect : player.getActivePotionEffects()) {
-            player.removeActivePotionEffect(effect.getPotion());
-        }
+        player.clearActivePotions();
     }
 
     /**

--- a/src/main/java/net/tropicraft/core/common/minigames/definitions/survive_the_tide/SurviveTheTideMinigameDefinition.java
+++ b/src/main/java/net/tropicraft/core/common/minigames/definitions/survive_the_tide/SurviveTheTideMinigameDefinition.java
@@ -251,7 +251,7 @@ public class SurviveTheTideMinigameDefinition implements IMinigameDefinition {
 
     @Override
     public void onPreStart() {
-        this.fetchBaseMap();
+        fetchBaseMap(this.server);
     }
 
     @Override
@@ -349,27 +349,41 @@ public class SurviveTheTideMinigameDefinition implements IMinigameDefinition {
         }
     }
 
-    private void fetchBaseMap() {
-        File worldFile = this.server.getWorld(DimensionType.OVERWORLD).getSaveHandler().getWorldDirectory();
+    private static void saveMapTo(File from, File to) {
+        try {
+            if (from.exists()) {
+                FileUtils.deleteDirectory(to);
+
+                if (to.mkdirs()) {
+                    FileUtils.copyDirectory(from, to);
+                }
+            } else {
+                LOGGER.info("Island royale base map doesn't exist in " + to.getPath() + ", add first before it can copy and replace each game start.");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    public static void saveBaseMap(MinecraftServer server) {
+        File worldFile = server.getWorld(DimensionType.OVERWORLD).getSaveHandler().getWorldDirectory();
 
         File baseMapsFile = new File(worldFile, "minigame_base_maps");
 
         File islandRoyaleBase = new File(baseMapsFile, "hunger_games");
         File islandRoyaleCurrent = new File(worldFile, "tropicraft/hunger_games");
 
-        try {
-            if (islandRoyaleBase.exists()) {
-                FileUtils.deleteDirectory(islandRoyaleCurrent);
+        saveMapTo(islandRoyaleCurrent, islandRoyaleBase);
+    }
 
-                if (islandRoyaleCurrent.mkdirs()) {
-                    FileUtils.copyDirectory(islandRoyaleBase, islandRoyaleCurrent);
-                }
-            } else {
-                LOGGER.info("Island royale base map doesn't exist in " + islandRoyaleBase.getPath() + ", add first before it can copy and replace each game start.");
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    public static void fetchBaseMap(MinecraftServer server) {
+        File worldFile = server.getWorld(DimensionType.OVERWORLD).getSaveHandler().getWorldDirectory();
+
+        File baseMapsFile = new File(worldFile, "minigame_base_maps");
+
+        File islandRoyaleBase = new File(baseMapsFile, "hunger_games");
+        File islandRoyaleCurrent = new File(worldFile, "tropicraft/hunger_games");
+
+        saveMapTo(islandRoyaleBase, islandRoyaleCurrent);
     }
 
     private void processWaterLevel(World world) {


### PR DESCRIPTION
- Includes double-checks to make sure players can't accidentally save or reset.
- Fixes effects not being removed after minigame.