### PR TITLE
Improve mangrove biome, fix spawns in all water biomes

### DIFF
--- a/src/generated/resources/data/tropicraft/worldgen/biome/kelp_forest.json
+++ b/src/generated/resources/data/tropicraft/worldgen/biome/kelp_forest.json
@@ -99,7 +99,8 @@
     ],
     "creature": [],
     "ambient": [],
-    "water_creature": [
+    "water_creature": [],
+    "water_ambient": [
       {
         "type": "tropicraft:marlin",
         "weight": 10,
@@ -161,7 +162,6 @@
         "maxCount": 1
       }
     ],
-    "water_ambient": [],
     "misc": []
   },
   "spawn_costs": {},

--- a/src/generated/resources/data/tropicraft/worldgen/biome/mangroves.json
+++ b/src/generated/resources/data/tropicraft/worldgen/biome/mangroves.json
@@ -1,6 +1,7 @@
 {
   "effects": {
     "sky_color": 7907327,
+    "grass_color": 3060507,
     "fog_color": 12638463,
     "water_color": 6734231,
     "water_fog_color": 800034
@@ -34,13 +35,15 @@
     ],
     [],
     [
-      "tropicraft:tropics_flowers",
-      "tropicraft:iris_flowers",
+      "tropicraft:small_mangrove",
       "tropicraft:short_mangrove",
       "tropicraft:tall_mangrove",
-      "minecraft:seagrass_swamp",
+      "tropicraft:tropics_flowers",
+      "tropicraft:iris_flowers",
+      "minecraft:seagrass_deep_warm",
       "tropicraft:mangrove_reeds",
-      "minecraft:patch_grass_badlands",
+      "minecraft:patch_grass_plain",
+      "minecraft:patch_waterlilly",
       "minecraft:patch_tall_grass"
     ]
   ],
@@ -116,7 +119,8 @@
         "maxCount": 15
       }
     ],
-    "water_creature": [
+    "water_creature": [],
+    "water_ambient": [
       {
         "type": "tropicraft:piranha",
         "weight": 20,
@@ -128,6 +132,24 @@
         "weight": 20,
         "minCount": 1,
         "maxCount": 8
+      },
+      {
+        "type": "tropicraft:starfish",
+        "weight": 4,
+        "minCount": 1,
+        "maxCount": 4
+      },
+      {
+        "type": "tropicraft:sea_urchin",
+        "weight": 4,
+        "minCount": 1,
+        "maxCount": 4
+      },
+      {
+        "type": "tropicraft:seahorse",
+        "weight": 6,
+        "minCount": 6,
+        "maxCount": 12
       },
       {
         "type": "minecraft:squid",
@@ -146,9 +168,14 @@
         "weight": 4,
         "minCount": 1,
         "maxCount": 5
+      },
+      {
+        "type": "minecraft:tropical_fish",
+        "weight": 12,
+        "minCount": 1,
+        "maxCount": 5
       }
     ],
-    "water_ambient": [],
     "misc": []
   },
   "spawn_costs": {},
@@ -157,6 +184,6 @@
   "temperature": 2.0,
   "downfall": 1.5,
   "category": "swamp",
-  "depth": -0.2,
-  "scale": 0.0
+  "depth": -0.275,
+  "scale": -0.03
 }

--- a/src/generated/resources/data/tropicraft/worldgen/biome/tropics_ocean.json
+++ b/src/generated/resources/data/tropicraft/worldgen/biome/tropics_ocean.json
@@ -110,7 +110,8 @@
         "maxCount": 10
       }
     ],
-    "water_creature": [
+    "water_creature": [],
+    "water_ambient": [
       {
         "type": "tropicraft:marlin",
         "weight": 10,
@@ -172,7 +173,6 @@
         "maxCount": 1
       }
     ],
-    "water_ambient": [],
     "misc": []
   },
   "spawn_costs": {},

--- a/src/generated/resources/data/tropicraft/worldgen/biome/tropics_river.json
+++ b/src/generated/resources/data/tropicraft/worldgen/biome/tropics_river.json
@@ -97,7 +97,8 @@
     ],
     "creature": [],
     "ambient": [],
-    "water_creature": [
+    "water_creature": [],
+    "water_ambient": [
       {
         "type": "tropicraft:piranha",
         "weight": 20,
@@ -129,7 +130,6 @@
         "maxCount": 5
       }
     ],
-    "water_ambient": [],
     "misc": []
   },
   "spawn_costs": {},

--- a/src/generated/resources/data/tropicraft/worldgen/configured_feature/small_mangrove.json
+++ b/src/generated/resources/data/tropicraft/worldgen/configured_feature/small_mangrove.json
@@ -4,7 +4,7 @@
       "config": {
         "feature": {
           "config": {
-            "max_water_depth": 1,
+            "max_water_depth": 0,
             "ignore_vines": true,
             "heightmap": "OCEAN_FLOOR",
             "minimum_size": {
@@ -37,14 +37,14 @@
             "foliage_placer": {
               "radius": 0,
               "offset": 0,
-              "type": "tropicraft:mangrove"
+              "type": "tropicraft:small_mangrove"
             },
             "trunk_placer": {
-              "base_height": 5,
-              "height_rand_a": 3,
+              "base_height": 2,
+              "height_rand_a": 1,
               "height_rand_b": 0,
               "roots_block": "tropicraft:mangrove_roots",
-              "type": "tropicraft:mangrove"
+              "type": "tropicraft:small_mangrove"
             }
           },
           "type": "tropicraft:mangrove_tree"
@@ -68,7 +68,7 @@
     "decorator": {
       "config": {
         "count": 2,
-        "extra_chance": 0.6,
+        "extra_chance": 0.3,
         "extra_count": 1
       },
       "type": "minecraft:count_extra"

--- a/src/generated/resources/data/tropicraft/worldgen/configured_feature/tall_mangrove.json
+++ b/src/generated/resources/data/tropicraft/worldgen/configured_feature/tall_mangrove.json
@@ -35,20 +35,19 @@
               "type": "minecraft:simple_state_provider"
             },
             "foliage_placer": {
-              "radius": 2,
-              "offset": 4,
-              "height": 4,
-              "type": "minecraft:fancy_foliage_placer"
+              "radius": 0,
+              "offset": 0,
+              "type": "tropicraft:mangrove"
             },
             "trunk_placer": {
               "base_height": 7,
-              "height_rand_a": 4,
-              "height_rand_b": 4,
+              "height_rand_a": 3,
+              "height_rand_b": 0,
               "roots_block": "tropicraft:mangrove_roots",
               "type": "tropicraft:mangrove"
             }
           },
-          "type": "minecraft:tree"
+          "type": "tropicraft:mangrove_tree"
         },
         "decorator": {
           "config": {

--- a/src/main/java/net/tropicraft/Tropicraft.java
+++ b/src/main/java/net/tropicraft/Tropicraft.java
@@ -50,6 +50,7 @@ import net.tropicraft.core.common.dimension.feature.jigsaw.*;
 import net.tropicraft.core.common.dimension.feature.jigsaw.piece.NoRotateSingleJigsawPiece;
 import net.tropicraft.core.common.dimension.feature.jigsaw.piece.SingleNoAirJigsawPiece;
 import net.tropicraft.core.common.dimension.feature.pools.TropicraftTemplatePools;
+import net.tropicraft.core.common.dimension.feature.tree.TropicraftFoliagePlacers;
 import net.tropicraft.core.common.dimension.feature.tree.TropicraftTrunkPlacers;
 import net.tropicraft.core.common.dimension.surfacebuilders.TropicraftConfiguredSurfaceBuilders;
 import net.tropicraft.core.common.dimension.surfacebuilders.TropicraftSurfaceBuilders;
@@ -102,6 +103,7 @@ public class Tropicraft {
         TropicraftEntities.ENTITIES.register(modBus);
         TropicraftCarvers.CARVERS.register(modBus);
         TropicraftFeatures.FEATURES.register(modBus);
+        TropicraftFoliagePlacers.FOLIAGE_PLACERS.register(modBus);
         TropicraftFeatures.STRUCTURES.register(modBus);
         TropicraftSurfaceBuilders.SURFACE_BUILDERS.register(modBus);
         TropicraftBlockStateProviders.BLOCK_STATE_PROVIDERS.register(modBus);

--- a/src/main/java/net/tropicraft/core/common/dimension/biome/TropicraftBiomes.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/biome/TropicraftBiomes.java
@@ -313,27 +313,30 @@ public final class TropicraftBiomes {
 
         carvers.addLand(generation);
 
-        features.addTropicsFlowers(generation);
         features.addMangroveTrees(generation);
+        features.addTropicsFlowers(generation);
 
-        generation.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Features.SEAGRASS_SWAMP);
+        generation.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Features.SEAGRASS_DEEP_WARM);
         features.addMangroveReeds(generation);
 
-        DefaultBiomeFeatures.withBadlandsGrass(generation);
+        generation.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Features.PATCH_GRASS_PLAIN);
+        generation.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Features.PATCH_WATERLILLY);
+
         DefaultBiomeFeatures.withTallGrass(generation);
 
         MobSpawnInfo.Builder spawns = defaultSpawns();
         spawns.withSpawner(EntityClassification.AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.FAILGULL.get(), 10, 5, 15));
         spawns.withSpawner(EntityClassification.MONSTER, new MobSpawnInfo.Spawners(TropicraftEntities.TREE_FROG.get(), 4, 4, 4));
 
-        addRiverWaterCreatures(spawns);
+        addMangroveWaterCreatures(spawns);
 
         BiomeAmbience.Builder ambience = defaultAmbience();
         ambience.setWaterColor(0x66C197).setWaterFogColor(0x0C3522);
+        ambience.withGrassColor(0x2eb31b);
 
         return new Biome.Builder()
                 .precipitation(Biome.RainType.RAIN)
-                .depth(-0.2F).scale(0.0F)
+                .depth(-0.275F).scale(-0.03F)
                 .temperature(2.0F).downfall(1.5F)
                 .category(Biome.Category.SWAMP)
                 .withGenerationSettings(generation.build())
@@ -343,24 +346,36 @@ public final class TropicraftBiomes {
     }
 
     private void addOceanWaterCreatures(MobSpawnInfo.Builder spawns) {
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.MARLIN.get(), 10, 1, 4));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.MAN_O_WAR.get(), 2, 1, 1));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.STARFISH.get(), 4, 1, 4));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.SEA_URCHIN.get(), 4, 1, 4));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.DOLPHIN.get(), 3, 4, 7));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.SEAHORSE.get(), 6, 6, 12));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.SEA_TURTLE.get(), 6, 3, 8));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.TROPICAL_FISH.get(), 20, 4, 8));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.EAGLE_RAY.get(), 6, 1, 1));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.HAMMERHEAD.get(), 2, 1, 1));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.MARLIN.get(), 10, 1, 4));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.MAN_O_WAR.get(), 2, 1, 1));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.STARFISH.get(), 4, 1, 4));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.SEA_URCHIN.get(), 4, 1, 4));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.DOLPHIN.get(), 3, 4, 7));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.SEAHORSE.get(), 6, 6, 12));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.SEA_TURTLE.get(), 6, 3, 8));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.TROPICAL_FISH.get(), 20, 4, 8));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.EAGLE_RAY.get(), 6, 1, 1));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.HAMMERHEAD.get(), 2, 1, 1));
     }
 
     private void addRiverWaterCreatures(MobSpawnInfo.Builder spawns) {
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.PIRANHA.get(), 20, 1, 12));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(TropicraftEntities.RIVER_SARDINE.get(), 20, 1, 8));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(EntityType.SQUID, 8, 1, 4));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(EntityType.COD, 4, 1, 5));
-        spawns.withSpawner(EntityClassification.WATER_CREATURE, new MobSpawnInfo.Spawners(EntityType.SALMON, 4, 1, 5));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.PIRANHA.get(), 20, 1, 12));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.RIVER_SARDINE.get(), 20, 1, 8));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(EntityType.SQUID, 8, 1, 4));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(EntityType.COD, 4, 1, 5));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(EntityType.SALMON, 4, 1, 5));
+    }
+
+    private void addMangroveWaterCreatures(MobSpawnInfo.Builder spawns) {
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.PIRANHA.get(), 20, 1, 12));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.RIVER_SARDINE.get(), 20, 1, 8));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.STARFISH.get(), 4, 1, 4));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.SEA_URCHIN.get(), 4, 1, 4));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(TropicraftEntities.SEAHORSE.get(), 6, 6, 12));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(EntityType.SQUID, 8, 1, 4));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(EntityType.COD, 4, 1, 5));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(EntityType.SALMON, 4, 1, 5));
+        spawns.withSpawner(EntityClassification.WATER_AMBIENT, new MobSpawnInfo.Spawners(EntityType.TROPICAL_FISH, 12, 1, 5));
     }
 
     private BiomeGenerationSettings.Builder defaultGeneration() {

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/TropicraftConfiguredFeatures.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/TropicraftConfiguredFeatures.java
@@ -16,6 +16,7 @@ import net.minecraft.world.gen.placement.AtSurfaceWithExtraConfig;
 import net.minecraft.world.gen.placement.CaveEdgeConfig;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.placement.TopSolidRangeConfig;
+import net.minecraft.world.gen.treedecorator.LeaveVineTreeDecorator;
 import net.minecraftforge.fml.RegistryObject;
 import net.tropicraft.Constants;
 import net.tropicraft.core.common.TropicraftTags;
@@ -25,7 +26,10 @@ import net.tropicraft.core.common.dimension.feature.block_state_provider.NoiseFr
 import net.tropicraft.core.common.dimension.feature.config.FruitTreeConfig;
 import net.tropicraft.core.common.dimension.feature.config.HomeTreeBranchConfig;
 import net.tropicraft.core.common.dimension.feature.config.RainforestVinesConfig;
+import net.tropicraft.core.common.dimension.feature.tree.MangroveFoliagePlacer;
 import net.tropicraft.core.common.dimension.feature.tree.MangroveTrunkPlacer;
+import net.tropicraft.core.common.dimension.feature.tree.SmallMangroveFoliagePlacer;
+import net.tropicraft.core.common.dimension.feature.tree.SmallMangroveTrunkPlacer;
 
 import java.util.OptionalInt;
 import java.util.function.Function;
@@ -48,6 +52,7 @@ public final class TropicraftConfiguredFeatures {
     public final ConfiguredFeature<?, ?> eih;
     public final ConfiguredFeature<?, ?> shortMangrove;
     public final ConfiguredFeature<?, ?> tallMangrove;
+    public final ConfiguredFeature<?, ?> smallMangrove;
 
     public final ConfiguredFeature<?, ?> pineapplePatch;
     public final ConfiguredFeature<?, ?> tropicsFlowers;
@@ -106,11 +111,11 @@ public final class TropicraftConfiguredFeatures {
                 f -> f.withConfiguration(new RainforestVinesConfig()).square().count(50)
         );
 
-        this.shortMangrove = features.tree("short_mangrove",
+        this.shortMangrove = features.mangrove("short_mangrove",
                 new BaseTreeFeatureConfig.Builder(
                         new SimpleBlockStateProvider(TropicraftBlocks.MANGROVE_LOG.get().getDefaultState()),
                         new SimpleBlockStateProvider(Blocks.ACACIA_LEAVES.getDefaultState()),
-                        new FancyFoliagePlacer(FeatureSpread.create(2), FeatureSpread.create(4), 4),
+                        new MangroveFoliagePlacer(FeatureSpread.create(0), FeatureSpread.create(0)),
                         new MangroveTrunkPlacer(5, 3, 0, TropicraftBlocks.MANGROVE_ROOTS.get()),
                         new TwoLayerFeature(0, 0, 0, OptionalInt.of(4))
                 )
@@ -120,18 +125,31 @@ public final class TropicraftConfiguredFeatures {
                 2, 0.6F, 1
         );
 
-        this.tallMangrove = features.tree("tall_mangrove",
+        this.tallMangrove = features.mangrove("tall_mangrove",
                 new BaseTreeFeatureConfig.Builder(
                         new SimpleBlockStateProvider(TropicraftBlocks.MANGROVE_LOG.get().getDefaultState()),
                         new SimpleBlockStateProvider(Blocks.ACACIA_LEAVES.getDefaultState()),
-                        new FancyFoliagePlacer(FeatureSpread.create(2), FeatureSpread.create(4), 4),
-                        new MangroveTrunkPlacer(7, 4, 4, TropicraftBlocks.MANGROVE_ROOTS.get()),
+                        new MangroveFoliagePlacer(FeatureSpread.create(0), FeatureSpread.create(0)),
+                        new MangroveTrunkPlacer(7, 3, 0, TropicraftBlocks.MANGROVE_ROOTS.get()),
                         new TwoLayerFeature(0, 0, 0, OptionalInt.of(4))
                 )
                         .setMaxWaterDepth(2)
                         .setIgnoreVines()
                         .build(),
                 1, 0.8F, 1
+        );
+
+        this.smallMangrove = features.mangrove("small_mangrove",
+                new BaseTreeFeatureConfig.Builder(
+                        new SimpleBlockStateProvider(TropicraftBlocks.MANGROVE_LOG.get().getDefaultState()),
+                        new SimpleBlockStateProvider(Blocks.ACACIA_LEAVES.getDefaultState()),
+                        new SmallMangroveFoliagePlacer(FeatureSpread.create(0), FeatureSpread.create(0)),
+                        new SmallMangroveTrunkPlacer(2, 1, 0, TropicraftBlocks.MANGROVE_ROOTS.get()),
+                        new TwoLayerFeature(0, 0, 0, OptionalInt.of(4))
+                )
+                        .setIgnoreVines()
+                        .build(),
+                2, 0.3F, 1
         );
 
         this.eih = features.noConfig("eih", TropicraftFeatures.EIH,
@@ -270,6 +288,7 @@ public final class TropicraftConfiguredFeatures {
     }
 
     public void addMangroveTrees(BiomeGenerationSettings.Builder generation) {
+        generation.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, this.smallMangrove);
         generation.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, this.shortMangrove);
         generation.withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, this.tallMangrove);
     }
@@ -343,6 +362,14 @@ public final class TropicraftConfiguredFeatures {
 
         public <F extends Feature<?>> ConfiguredFeature<?, ?> tree(String id, BaseTreeFeatureConfig config, int count, float extraChance, int extraCount) {
             return this.register(id, Feature.TREE, feature -> {
+                return feature.withConfiguration(config)
+                        .withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT)
+                        .withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(count, extraChance, extraCount)));
+            });
+        }
+
+        public <F extends Feature<?>> ConfiguredFeature<?, ?> mangrove(String id, BaseTreeFeatureConfig config, int count, float extraChance, int extraCount) {
+            return this.register(id, TropicraftFeatures.MANGROVE_TREE.get(), feature -> {
                 return feature.withConfiguration(config)
                         .withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT)
                         .withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(count, extraChance, extraCount)));

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/TropicraftFeatures.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/TropicraftFeatures.java
@@ -3,8 +3,10 @@ package net.tropicraft.core.common.dimension.feature;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.world.gen.GenerationStage;
 import net.minecraft.world.gen.Heightmap;
+import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.feature.NoFeatureConfig;
+import net.minecraft.world.gen.feature.TreeFeature;
 import net.minecraft.world.gen.feature.jigsaw.JigsawPattern.PlacementBehaviour;
 import net.minecraft.world.gen.feature.structure.Structure;
 import net.minecraft.world.gen.feature.structure.VillageConfig;
@@ -48,6 +50,7 @@ public class TropicraftFeatures {
     public static final RegistryObject<CoffeePlantFeature> COFFEE_BUSH = register("coffee_bush", () -> new CoffeePlantFeature(NoFeatureConfig.CODEC));
 
     public static final RegistryObject<ReedsFeature> REEDS = register("reeds", () -> new ReedsFeature(NoFeatureConfig.CODEC));
+    public static final RegistryObject<MangroveTreeFeature> MANGROVE_TREE = register("mangrove_tree", () -> new MangroveTreeFeature((TreeFeature) Feature.TREE, BaseTreeFeatureConfig.CODEC));
 
     public static final PlacementBehaviour KOA_PATH = PlacementBehaviour.create("KOA_PATH", Constants.MODID + ":koa_path",
             ImmutableList.of(new SmoothingGravityProcessor(Heightmap.Type.WORLD_SURFACE_WG, -1), new SinkInGroundProcessor(), new SteepPathProcessor(), new StructureSupportsProcessor(false, ImmutableList.of(TropicraftBlocks.BAMBOO_FENCE.getId()))));

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/MangroveFoliagePlacer.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/MangroveFoliagePlacer.java
@@ -1,0 +1,47 @@
+package net.tropicraft.core.common.dimension.feature.tree;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MutableBoundingBox;
+import net.minecraft.world.gen.IWorldGenerationReader;
+import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
+import net.minecraft.world.gen.feature.FeatureSpread;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacer;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacerType;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.Set;
+
+public final class MangroveFoliagePlacer extends FoliagePlacer {
+    public static final Codec<MangroveFoliagePlacer> CODEC = RecordCodecBuilder.create((instance) -> {
+        return func_242830_b(instance).apply(instance, MangroveFoliagePlacer::new);
+    });
+
+    public MangroveFoliagePlacer(FeatureSpread radius, FeatureSpread offset) {
+        super(radius, offset);
+    }
+
+    @Override
+    protected FoliagePlacerType<?> getPlacerType() {
+        return TropicraftFoliagePlacers.MANGROVE.get();
+    }
+
+    @Override
+    protected void func_230372_a_(IWorldGenerationReader world, Random random, BaseTreeFeatureConfig config, int p_230372_4_, Foliage node, int p_230372_6_, int radius, Set<BlockPos> p_230372_8_, int p_230372_9_, MutableBoundingBox p_230372_10_) {
+        this.func_236753_a_(world, random, config, node.func_236763_a_(), node.func_236764_b_(), p_230372_8_, 1, node.func_236765_c_(), p_230372_10_);
+        this.func_236753_a_(world, random, config, node.func_236763_a_(), node.func_236764_b_() + 1, p_230372_8_, 0, node.func_236765_c_(), p_230372_10_);
+        this.func_236753_a_(world, random, config, node.func_236763_a_(), node.func_236764_b_(), p_230372_8_, -1, node.func_236765_c_(), p_230372_10_);
+    }
+
+    @Override
+    public int func_230374_a_(Random p_230374_1_, int p_230374_2_, BaseTreeFeatureConfig p_230374_3_) {
+        return 0;
+    }
+
+    @Override
+    protected boolean func_230373_a_(Random random, int dx, int y, int dz, int radius, boolean giantTrunk) {
+        return radius != 0 && dx == radius && dz == radius && (random.nextInt(2) == 0 || y == 0);
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/MangroveTreeFeature.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/MangroveTreeFeature.java
@@ -1,0 +1,73 @@
+package net.tropicraft.core.common.dimension.feature.tree;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ISeedReader;
+import net.minecraft.world.gen.ChunkGenerator;
+import net.minecraft.world.gen.Heightmap;
+import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.TreeFeature;
+
+import java.util.Random;
+
+public class MangroveTreeFeature extends Feature<BaseTreeFeatureConfig> {
+    private final TreeFeature backing;
+
+    public MangroveTreeFeature(TreeFeature backing, Codec<BaseTreeFeatureConfig> codec) {
+        super(codec);
+        this.backing = backing;
+    }
+
+    @Override
+    public boolean generate(ISeedReader reader, ChunkGenerator generator, Random rand, BlockPos pos, BaseTreeFeatureConfig config) {
+        BlockPos genPos;
+        boolean secondWaterCheck = false;
+        if (!config.forcePlacement) {
+            int floorY = reader.getHeight(Heightmap.Type.OCEAN_FLOOR, pos).getY();
+            int surfaceY = reader.getHeight(Heightmap.Type.WORLD_SURFACE, pos).getY();
+            if (surfaceY - floorY > 3 || config.maxWaterDepth == 0) {
+                return false;
+            } else if (surfaceY - floorY > config.maxWaterDepth) {
+                secondWaterCheck = true;
+            }
+
+            int y;
+            if (config.heightmap == Heightmap.Type.OCEAN_FLOOR) {
+                y = floorY;
+            } else if (config.heightmap == Heightmap.Type.WORLD_SURFACE) {
+                y = surfaceY;
+            } else {
+                y = reader.getHeight(config.heightmap, pos).getY();
+            }
+
+            genPos = new BlockPos(pos.getX(), y, pos.getZ());
+        } else {
+            genPos = pos;
+        }
+
+        if (secondWaterCheck) {
+            int surfaceY = reader.getHeight(Heightmap.Type.WORLD_SURFACE, pos).getY();
+            genPos = new BlockPos(pos.getX(), surfaceY - config.maxWaterDepth, pos.getZ());
+        }
+        BlockState downState = reader.getBlockState(genPos.down());
+        boolean reset = false;
+
+        if (downState.isIn(BlockTags.SAND) || downState.getFluidState().isTagged(FluidTags.WATER)) {
+            reset = true;
+            reader.setBlockState(genPos.down(), Blocks.DIRT.getDefaultState(), 3);
+        }
+
+        boolean ret = this.backing.generate(reader, generator, rand, pos, config);
+
+        if (reset) {
+            reader.setBlockState(genPos.down(), downState, 3);
+        }
+
+        return ret;
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/SmallMangroveFoliagePlacer.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/SmallMangroveFoliagePlacer.java
@@ -1,0 +1,57 @@
+package net.tropicraft.core.common.dimension.feature.tree;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MutableBoundingBox;
+import net.minecraft.world.gen.IWorldGenerationReader;
+import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
+import net.minecraft.world.gen.feature.FeatureSpread;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacer;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacerType;
+
+import java.util.Random;
+import java.util.Set;
+
+public final class SmallMangroveFoliagePlacer extends FoliagePlacer {
+    public static final Codec<SmallMangroveFoliagePlacer> CODEC = RecordCodecBuilder.create((instance) -> {
+        return func_242830_b(instance).apply(instance, SmallMangroveFoliagePlacer::new);
+    });
+
+    public SmallMangroveFoliagePlacer(FeatureSpread radius, FeatureSpread offset) {
+        super(radius, offset);
+    }
+
+    @Override
+    protected FoliagePlacerType<?> getPlacerType() {
+        return TropicraftFoliagePlacers.SMALL_MANGROVE.get();
+    }
+
+    @Override
+    protected void func_230372_a_(IWorldGenerationReader world, Random random, BaseTreeFeatureConfig config, int p_230372_4_, Foliage node, int p_230372_6_, int radius, Set<BlockPos> p_230372_8_, int p_230372_9_, MutableBoundingBox p_230372_10_) {
+        this.func_236753_a_(world, random, config, node.func_236763_a_(), node.func_236764_b_(), p_230372_8_, 1, node.func_236765_c_(), p_230372_10_);
+        this.func_236753_a_(world, random, config, node.func_236763_a_(), node.func_236764_b_(), p_230372_8_, 0, node.func_236765_c_(), p_230372_10_);
+    }
+
+    @Override
+    public int func_230374_a_(Random p_230374_1_, int p_230374_2_, BaseTreeFeatureConfig p_230374_3_) {
+        return 0;
+    }
+
+    @Override
+    protected boolean func_230373_a_(Random random, int dx, int y, int dz, int radius, boolean giantTrunk) {
+        if (y == 0) {
+            return radius != 0 && dx == radius && dz == radius && random.nextInt(2) == 0;
+        }
+
+        if (dx == 0 && dz == 0) {
+            return false;
+        }
+
+        if (random.nextBoolean()) {
+            return true;
+        }
+
+        return dx == radius && dz == radius;
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/SmallMangroveTrunkPlacer.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/SmallMangroveTrunkPlacer.java
@@ -1,0 +1,71 @@
+package net.tropicraft.core.common.dimension.feature.tree;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MutableBoundingBox;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.gen.IWorldGenerationReader;
+import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
+import net.minecraft.world.gen.feature.TreeFeature;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacer;
+import net.minecraft.world.gen.trunkplacer.AbstractTrunkPlacer;
+import net.minecraft.world.gen.trunkplacer.TrunkPlacerType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+public class SmallMangroveTrunkPlacer extends AbstractTrunkPlacer {
+    public static final Codec<SmallMangroveTrunkPlacer> CODEC = RecordCodecBuilder.create(instance -> {
+        return getAbstractTrunkCodec(instance)
+                .and(Registry.BLOCK.fieldOf("roots_block").forGetter(c -> c.rootsBlock))
+                .apply(instance, SmallMangroveTrunkPlacer::new);
+    });
+
+    private final Block rootsBlock;
+
+    public SmallMangroveTrunkPlacer(int baseHeight, int heightRandA, int heightRandB, Block rootsBlock) {
+        super(baseHeight, heightRandA, heightRandB);
+        this.rootsBlock = rootsBlock;
+    }
+
+    @Override
+    protected TrunkPlacerType<?> getPlacerType() {
+        return TropicraftTrunkPlacers.SMALL_MANGROVE;
+    }
+
+    @Override
+    public List<FoliagePlacer.Foliage> getFoliages(IWorldGenerationReader world, Random random, int height, BlockPos origin, Set<BlockPos> logs, MutableBoundingBox bounds, BaseTreeFeatureConfig config) {
+        func_236909_a_(world, origin.down());
+
+        for (int i = 0; i < height; ++i) {
+            func_236911_a_(world, random, origin.up(i), logs, bounds, config);
+        }
+
+        generateRoots(world, random, origin, 0);
+
+        return ImmutableList.of(new FoliagePlacer.Foliage(origin.up(height - 1), 1, false));
+    }
+
+    private void generateRoots(IWorldGenerationReader world, Random random, BlockPos origin, int depth) {
+        for (Direction direction : Direction.Plane.HORIZONTAL) {
+            BlockPos offset = origin.offset(direction);
+
+            if (world.hasBlockState(offset, AbstractBlock.AbstractBlockState::isAir)) {
+                if (world.hasBlockState(offset.down(), state -> state.getMaterial().isOpaque())) {
+                    TreeFeature.setBlockStateWithoutUpdate(world, offset, this.rootsBlock.getDefaultState());
+
+                    if (depth < 2 && random.nextInt(depth + 2) == 0) {
+                        generateRoots(world, random, offset, depth + 1);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/TropicraftFoliagePlacers.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/TropicraftFoliagePlacers.java
@@ -1,0 +1,19 @@
+package net.tropicraft.core.common.dimension.feature.tree;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacer;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacerType;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tropicraft.Constants;
+
+public final class TropicraftFoliagePlacers {
+    public static final DeferredRegister<FoliagePlacerType<?>> FOLIAGE_PLACERS = DeferredRegister.create(ForgeRegistries.FOLIAGE_PLACER_TYPES, Constants.MODID);
+    public static RegistryObject<FoliagePlacerType<MangroveFoliagePlacer>> MANGROVE = register("mangrove", MangroveFoliagePlacer.CODEC);
+    public static RegistryObject<FoliagePlacerType<SmallMangroveFoliagePlacer>> SMALL_MANGROVE = register("small_mangrove", SmallMangroveFoliagePlacer.CODEC);
+
+    private static <T extends FoliagePlacer> RegistryObject<FoliagePlacerType<T>> register(String name, Codec<T> codec) {
+        return FOLIAGE_PLACERS.register(name, () -> new FoliagePlacerType<>(codec));
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/TropicraftTrunkPlacers.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/TropicraftTrunkPlacers.java
@@ -9,6 +9,7 @@ import net.tropicraft.Constants;
 
 public final class TropicraftTrunkPlacers {
     public static final TrunkPlacerType<MangroveTrunkPlacer> MANGROVE = register("mangrove", MangroveTrunkPlacer.CODEC);
+    public static final TrunkPlacerType<SmallMangroveTrunkPlacer> SMALL_MANGROVE = register("small_mangrove", SmallMangroveTrunkPlacer.CODEC);
 
     private static <T extends AbstractTrunkPlacer> TrunkPlacerType<T> register(String name, Codec<T> codec) {
         return Registry.register(Registry.TRUNK_REPLACER, new ResourceLocation(Constants.MODID, name), new TrunkPlacerType<>(codec));

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -49,5 +49,8 @@ public net.minecraft.world.gen.feature.structure.Structure field_236385_u_ # STE
 # Create custom TrunkPlayerType
 public net.minecraft.world.gen.trunkplacer.TrunkPlacerType <init>(Lcom/mojang/serialization/Codec;)V
 
+# Create custom FoliagePlacerType
+public net.minecraft.world.gen.foliageplacer.FoliagePlacerType <init>(Lcom/mojang/serialization/Codec;)V
+
 # Setting dimension cloud height
 public net.minecraft.client.world.DimensionRenderInfo field_239208_a_ # EFFECTS


### PR DESCRIPTION
Improves the mangrove biome in a few ways, and fixes mobs not spawning in water biomes as often as they should have been
* Adds new mangrove tree shape
* Adds new small mangrove tree to give the biome more ground cover
* Makes the mangrove biome flatter
* Allows mangrove trees to spawn on sand
* Allows mangrove trees to spawn floating on water
* Adds more decoration to mangrove biome (more grass, lilypads)
* Changes grass color of mangrove biome
* Swaps the spawn groups of tropicraft water mobs from WATER_CREATURE to WATER_AMBIENT to allow them to spawn like vanilla fish (only squid use the WATER_CREATURE spawn group)