### PR TITLE
Improve fruit tree generation

### DIFF
--- a/src/generated/resources/data/tropicraft/worldgen/configured_feature/grapefruit_tree.json
+++ b/src/generated/resources/data/tropicraft/worldgen/configured_feature/grapefruit_tree.json
@@ -4,34 +4,63 @@
       "config": {
         "feature": {
           "config": {
-            "wood": {
-              "Properties": {
-                "axis": "y"
-              },
-              "Name": "minecraft:oak_log"
+            "max_water_depth": 0,
+            "ignore_vines": false,
+            "heightmap": "OCEAN_FLOOR",
+            "minimum_size": {
+              "limit": 1,
+              "lower_size": 0,
+              "upper_size": 2,
+              "type": "minecraft:two_layers_feature_size"
             },
-            "sapling": {
-              "Properties": {
-                "stage": "0"
+            "decorators": [],
+            "trunk_provider": {
+              "state": {
+                "Properties": {
+                  "axis": "y"
+                },
+                "Name": "minecraft:oak_log"
               },
-              "Name": "tropicraft:grapefruit_sapling"
+              "type": "minecraft:simple_state_provider"
             },
-            "leaves": {
-              "Properties": {
-                "persistent": "false",
-                "distance": "7"
-              },
-              "Name": "tropicraft:fruit_leaves"
+            "leaves_provider": {
+              "entries": [
+                {
+                  "weight": 1,
+                  "data": {
+                    "Properties": {
+                      "persistent": "false",
+                      "distance": "7"
+                    },
+                    "Name": "tropicraft:fruit_leaves"
+                  }
+                },
+                {
+                  "weight": 1,
+                  "data": {
+                    "Properties": {
+                      "persistent": "false",
+                      "distance": "7"
+                    },
+                    "Name": "tropicraft:grapefruit_leaves"
+                  }
+                }
+              ],
+              "type": "minecraft:weighted_state_provider"
             },
-            "fruit_leaves": {
-              "Properties": {
-                "persistent": "false",
-                "distance": "7"
-              },
-              "Name": "tropicraft:grapefruit_leaves"
+            "foliage_placer": {
+              "radius": 0,
+              "offset": 0,
+              "type": "tropicraft:citrus"
+            },
+            "trunk_placer": {
+              "base_height": 6,
+              "height_rand_a": 3,
+              "height_rand_b": 0,
+              "type": "tropicraft:citrus"
             }
           },
-          "type": "tropicraft:fruit_tree"
+          "type": "minecraft:tree"
         },
         "decorator": {
           "config": {
@@ -52,7 +81,7 @@
     "decorator": {
       "config": {
         "count": 0,
-        "extra_chance": 0.2,
+        "extra_chance": 0.1,
         "extra_count": 1
       },
       "type": "minecraft:count_extra"

--- a/src/generated/resources/data/tropicraft/worldgen/configured_feature/lemon_tree.json
+++ b/src/generated/resources/data/tropicraft/worldgen/configured_feature/lemon_tree.json
@@ -4,34 +4,63 @@
       "config": {
         "feature": {
           "config": {
-            "wood": {
-              "Properties": {
-                "axis": "y"
-              },
-              "Name": "minecraft:oak_log"
+            "max_water_depth": 0,
+            "ignore_vines": false,
+            "heightmap": "OCEAN_FLOOR",
+            "minimum_size": {
+              "limit": 1,
+              "lower_size": 0,
+              "upper_size": 2,
+              "type": "minecraft:two_layers_feature_size"
             },
-            "sapling": {
-              "Properties": {
-                "stage": "0"
+            "decorators": [],
+            "trunk_provider": {
+              "state": {
+                "Properties": {
+                  "axis": "y"
+                },
+                "Name": "minecraft:oak_log"
               },
-              "Name": "tropicraft:lemon_sapling"
+              "type": "minecraft:simple_state_provider"
             },
-            "leaves": {
-              "Properties": {
-                "persistent": "false",
-                "distance": "7"
-              },
-              "Name": "tropicraft:fruit_leaves"
+            "leaves_provider": {
+              "entries": [
+                {
+                  "weight": 1,
+                  "data": {
+                    "Properties": {
+                      "persistent": "false",
+                      "distance": "7"
+                    },
+                    "Name": "tropicraft:fruit_leaves"
+                  }
+                },
+                {
+                  "weight": 1,
+                  "data": {
+                    "Properties": {
+                      "persistent": "false",
+                      "distance": "7"
+                    },
+                    "Name": "tropicraft:lemon_leaves"
+                  }
+                }
+              ],
+              "type": "minecraft:weighted_state_provider"
             },
-            "fruit_leaves": {
-              "Properties": {
-                "persistent": "false",
-                "distance": "7"
-              },
-              "Name": "tropicraft:lemon_leaves"
+            "foliage_placer": {
+              "radius": 0,
+              "offset": 0,
+              "type": "tropicraft:citrus"
+            },
+            "trunk_placer": {
+              "base_height": 6,
+              "height_rand_a": 3,
+              "height_rand_b": 0,
+              "type": "tropicraft:citrus"
             }
           },
-          "type": "tropicraft:fruit_tree"
+          "type": "minecraft:tree"
         },
         "decorator": {
           "config": {
@@ -52,7 +81,7 @@
     "decorator": {
       "config": {
         "count": 0,
-        "extra_chance": 0.2,
+        "extra_chance": 0.1,
         "extra_count": 1
       },
       "type": "minecraft:count_extra"

--- a/src/generated/resources/data/tropicraft/worldgen/configured_feature/lime_tree.json
+++ b/src/generated/resources/data/tropicraft/worldgen/configured_feature/lime_tree.json
@@ -4,34 +4,63 @@
       "config": {
         "feature": {
           "config": {
-            "wood": {
-              "Properties": {
-                "axis": "y"
-              },
-              "Name": "minecraft:oak_log"
+            "max_water_depth": 0,
+            "ignore_vines": false,
+            "heightmap": "OCEAN_FLOOR",
+            "minimum_size": {
+              "limit": 1,
+              "lower_size": 0,
+              "upper_size": 2,
+              "type": "minecraft:two_layers_feature_size"
             },
-            "sapling": {
-              "Properties": {
-                "stage": "0"
+            "decorators": [],
+            "trunk_provider": {
+              "state": {
+                "Properties": {
+                  "axis": "y"
+                },
+                "Name": "minecraft:oak_log"
               },
-              "Name": "tropicraft:lime_sapling"
+              "type": "minecraft:simple_state_provider"
             },
-            "leaves": {
-              "Properties": {
-                "persistent": "false",
-                "distance": "7"
-              },
-              "Name": "tropicraft:fruit_leaves"
+            "leaves_provider": {
+              "entries": [
+                {
+                  "weight": 1,
+                  "data": {
+                    "Properties": {
+                      "persistent": "false",
+                      "distance": "7"
+                    },
+                    "Name": "tropicraft:fruit_leaves"
+                  }
+                },
+                {
+                  "weight": 1,
+                  "data": {
+                    "Properties": {
+                      "persistent": "false",
+                      "distance": "7"
+                    },
+                    "Name": "tropicraft:lime_leaves"
+                  }
+                }
+              ],
+              "type": "minecraft:weighted_state_provider"
             },
-            "fruit_leaves": {
-              "Properties": {
-                "persistent": "false",
-                "distance": "7"
-              },
-              "Name": "tropicraft:lime_leaves"
+            "foliage_placer": {
+              "radius": 0,
+              "offset": 0,
+              "type": "tropicraft:citrus"
+            },
+            "trunk_placer": {
+              "base_height": 6,
+              "height_rand_a": 3,
+              "height_rand_b": 0,
+              "type": "tropicraft:citrus"
             }
           },
-          "type": "tropicraft:fruit_tree"
+          "type": "minecraft:tree"
         },
         "decorator": {
           "config": {
@@ -52,7 +81,7 @@
     "decorator": {
       "config": {
         "count": 0,
-        "extra_chance": 0.2,
+        "extra_chance": 0.1,
         "extra_count": 1
       },
       "type": "minecraft:count_extra"

--- a/src/generated/resources/data/tropicraft/worldgen/configured_feature/orange_tree.json
+++ b/src/generated/resources/data/tropicraft/worldgen/configured_feature/orange_tree.json
@@ -4,34 +4,63 @@
       "config": {
         "feature": {
           "config": {
-            "wood": {
-              "Properties": {
-                "axis": "y"
-              },
-              "Name": "minecraft:oak_log"
+            "max_water_depth": 0,
+            "ignore_vines": false,
+            "heightmap": "OCEAN_FLOOR",
+            "minimum_size": {
+              "limit": 1,
+              "lower_size": 0,
+              "upper_size": 2,
+              "type": "minecraft:two_layers_feature_size"
             },
-            "sapling": {
-              "Properties": {
-                "stage": "0"
+            "decorators": [],
+            "trunk_provider": {
+              "state": {
+                "Properties": {
+                  "axis": "y"
+                },
+                "Name": "minecraft:oak_log"
               },
-              "Name": "tropicraft:orange_sapling"
+              "type": "minecraft:simple_state_provider"
             },
-            "leaves": {
-              "Properties": {
-                "persistent": "false",
-                "distance": "7"
-              },
-              "Name": "tropicraft:fruit_leaves"
+            "leaves_provider": {
+              "entries": [
+                {
+                  "weight": 1,
+                  "data": {
+                    "Properties": {
+                      "persistent": "false",
+                      "distance": "7"
+                    },
+                    "Name": "tropicraft:fruit_leaves"
+                  }
+                },
+                {
+                  "weight": 1,
+                  "data": {
+                    "Properties": {
+                      "persistent": "false",
+                      "distance": "7"
+                    },
+                    "Name": "tropicraft:orange_leaves"
+                  }
+                }
+              ],
+              "type": "minecraft:weighted_state_provider"
             },
-            "fruit_leaves": {
-              "Properties": {
-                "persistent": "false",
-                "distance": "7"
-              },
-              "Name": "tropicraft:orange_leaves"
+            "foliage_placer": {
+              "radius": 0,
+              "offset": 0,
+              "type": "tropicraft:citrus"
+            },
+            "trunk_placer": {
+              "base_height": 6,
+              "height_rand_a": 3,
+              "height_rand_b": 0,
+              "type": "tropicraft:citrus"
             }
           },
-          "type": "tropicraft:fruit_tree"
+          "type": "minecraft:tree"
         },
         "decorator": {
           "config": {
@@ -52,7 +81,7 @@
     "decorator": {
       "config": {
         "count": 0,
-        "extra_chance": 0.2,
+        "extra_chance": 0.1,
         "extra_count": 1
       },
       "type": "minecraft:count_extra"

--- a/src/main/java/net/tropicraft/core/common/block/TropicraftTrees.java
+++ b/src/main/java/net/tropicraft/core/common/block/TropicraftTrees.java
@@ -1,5 +1,6 @@
 package net.tropicraft.core.common.block;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.trees.Tree;
@@ -13,30 +14,25 @@ import net.minecraft.util.registry.MutableRegistry;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.gen.ChunkGenerator;
-import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
-import net.minecraft.world.gen.feature.ConfiguredFeature;
-import net.minecraft.world.gen.feature.NoFeatureConfig;
+import net.minecraft.world.gen.blockstateprovider.SimpleBlockStateProvider;
+import net.minecraft.world.gen.blockstateprovider.WeightedBlockStateProvider;
+import net.minecraft.world.gen.feature.*;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.common.util.Constants;
 import net.tropicraft.core.common.dimension.feature.TropicraftFeatures;
 import net.tropicraft.core.common.dimension.feature.config.FruitTreeConfig;
+import net.tropicraft.core.common.dimension.feature.tree.CitrusFoliagePlacer;
+import net.tropicraft.core.common.dimension.feature.tree.CitrusTrunkPlacer;
 
 import javax.annotation.Nullable;
 import java.util.Random;
+import java.util.function.Supplier;
 
 public class TropicraftTrees {
-    public static final Tree GRAPEFRUIT = create((server, random, beehive) ->
-            TropicraftFeatures.FRUIT_TREE.get().withConfiguration(new FruitTreeConfig(TropicraftBlocks.GRAPEFRUIT_SAPLING, TropicraftBlocks.GRAPEFRUIT_LEAVES))
-    );
-    public static final Tree LEMON = create((server, random, beehive) ->
-            TropicraftFeatures.FRUIT_TREE.get().withConfiguration(new FruitTreeConfig(TropicraftBlocks.LEMON_SAPLING, TropicraftBlocks.LEMON_LEAVES))
-    );
-    public static final Tree LIME = create((server, random, beehive) ->
-            TropicraftFeatures.FRUIT_TREE.get().withConfiguration(new FruitTreeConfig(TropicraftBlocks.LIME_SAPLING, TropicraftBlocks.LIME_LEAVES))
-    );
-    public static final Tree ORANGE = create((server, random, beehive) ->
-            TropicraftFeatures.FRUIT_TREE.get().withConfiguration(new FruitTreeConfig(TropicraftBlocks.ORANGE_SAPLING, TropicraftBlocks.ORANGE_LEAVES))
-    );
+    public static final Tree GRAPEFRUIT = createFruit(TropicraftBlocks.GRAPEFRUIT_LEAVES);
+    public static final Tree LEMON = createFruit(TropicraftBlocks.LEMON_LEAVES);
+    public static final Tree LIME = createFruit(TropicraftBlocks.LIME_SAPLING);
+    public static final Tree ORANGE = createFruit(TropicraftBlocks.ORANGE_SAPLING);
 
     public static final Tree RAINFOREST = create((server, random, beehive) -> {
         final int treeType = random.nextInt(4);
@@ -64,6 +60,20 @@ public class TropicraftTrees {
 
     public static final Tree WHITE_MANGROVE = create("white_mangrove");
     public static final Tree RED_MANGROVE = create("red_mangrove");
+
+    private static Tree createFruit(Supplier<? extends Block> fruitLeaves) {
+        return create((server, random, beehive) -> {
+            BaseTreeFeatureConfig config = new BaseTreeFeatureConfig.Builder(
+                    new SimpleBlockStateProvider(Blocks.OAK_LOG.getDefaultState()),
+                    new WeightedBlockStateProvider().addWeightedBlockstate(TropicraftBlocks.FRUIT_LEAVES.get().getDefaultState(), 1).addWeightedBlockstate(fruitLeaves.get().getDefaultState(), 1),
+                    new CitrusFoliagePlacer(FeatureSpread.create(0), FeatureSpread.create(0)),
+                    new CitrusTrunkPlacer(6, 3, 0),
+                    new TwoLayerFeature(1, 0, 2)
+            ).build();
+
+           return Feature.TREE.withConfiguration(config);
+        });
+    }
 
     private static Tree create(String id) {
         RegistryKey<ConfiguredFeature<?, ?>> key = RegistryKey.getOrCreateKey(

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/TropicraftConfiguredFeatures.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/TropicraftConfiguredFeatures.java
@@ -10,6 +10,7 @@ import net.minecraft.world.gen.blockplacer.DoublePlantBlockPlacer;
 import net.minecraft.world.gen.blockplacer.SimpleBlockPlacer;
 import net.minecraft.world.gen.blockstateprovider.BlockStateProvider;
 import net.minecraft.world.gen.blockstateprovider.SimpleBlockStateProvider;
+import net.minecraft.world.gen.blockstateprovider.WeightedBlockStateProvider;
 import net.minecraft.world.gen.feature.*;
 import net.minecraft.world.gen.foliageplacer.FoliagePlacer;
 import net.minecraft.world.gen.placement.AtSurfaceWithExtraConfig;
@@ -25,10 +26,7 @@ import net.tropicraft.core.common.dimension.feature.block_state_provider.NoiseFr
 import net.tropicraft.core.common.dimension.feature.config.FruitTreeConfig;
 import net.tropicraft.core.common.dimension.feature.config.HomeTreeBranchConfig;
 import net.tropicraft.core.common.dimension.feature.config.RainforestVinesConfig;
-import net.tropicraft.core.common.dimension.feature.tree.MangroveFoliagePlacer;
-import net.tropicraft.core.common.dimension.feature.tree.MangroveTrunkPlacer;
-import net.tropicraft.core.common.dimension.feature.tree.SmallMangroveFoliagePlacer;
-import net.tropicraft.core.common.dimension.feature.tree.SmallMangroveTrunkPlacer;
+import net.tropicraft.core.common.dimension.feature.tree.*;
 
 import java.util.OptionalInt;
 import java.util.function.Function;
@@ -368,7 +366,15 @@ public final class TropicraftConfiguredFeatures {
         }
 
         public ConfiguredFeature<?, ?> fruitTree(String id, Supplier<? extends Block> sapling, Supplier<? extends Block> fruitLeaves) {
-            return this.sparseTree(id, TropicraftFeatures.FRUIT_TREE, new FruitTreeConfig(sapling, fruitLeaves), 0.2F);
+            BaseTreeFeatureConfig config = new BaseTreeFeatureConfig.Builder(
+                    new SimpleBlockStateProvider(Blocks.OAK_LOG.getDefaultState()),
+                    new WeightedBlockStateProvider().addWeightedBlockstate(TropicraftBlocks.FRUIT_LEAVES.get().getDefaultState(), 1).addWeightedBlockstate(fruitLeaves.get().getDefaultState(), 1),
+                    new CitrusFoliagePlacer(FeatureSpread.create(0), FeatureSpread.create(0)),
+                    new CitrusTrunkPlacer(6, 3, 0),
+                    new TwoLayerFeature(1, 0, 2)
+            ).build();
+
+            return this.tree(id, config, 0, 0.1F, 1);
         }
 
         public <C extends IFeatureConfig, F extends Feature<C>> ConfiguredFeature<?, ?> sparseTree(String id, RegistryObject<F> feature, C config, float chance) {

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/CitrusFoliagePlacer.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/CitrusFoliagePlacer.java
@@ -1,0 +1,50 @@
+package net.tropicraft.core.common.dimension.feature.tree;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MutableBoundingBox;
+import net.minecraft.world.gen.IWorldGenerationReader;
+import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
+import net.minecraft.world.gen.feature.FeatureSpread;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacer;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacerType;
+
+import java.util.Random;
+import java.util.Set;
+
+public final class CitrusFoliagePlacer extends FoliagePlacer {
+    public static final Codec<CitrusFoliagePlacer> CODEC = RecordCodecBuilder.create((instance) -> {
+        return func_242830_b(instance).apply(instance, CitrusFoliagePlacer::new);
+    });
+
+    public CitrusFoliagePlacer(FeatureSpread radius, FeatureSpread offset) {
+        super(radius, offset);
+    }
+
+    @Override
+    protected FoliagePlacerType<?> getPlacerType() {
+        return TropicraftFoliagePlacers.CITRUS.get();
+    }
+
+    @Override
+    protected void func_230372_a_(IWorldGenerationReader world, Random random, BaseTreeFeatureConfig config, int p_230372_4_, Foliage node, int p_230372_6_, int radius, Set<BlockPos> leaves, int p_230372_9_, MutableBoundingBox p_230372_10_) {
+        this.func_236753_a_(world, random, config, node.func_236763_a_(), 1, leaves, 1, node.func_236765_c_(), p_230372_10_);
+        this.func_236753_a_(world, random, config, node.func_236763_a_(), 2, leaves, 0, node.func_236765_c_(), p_230372_10_);
+
+        if (node.func_236764_b_() == 1) {
+            // Center leaf cluster, add another layer at the bottom
+            this.func_236753_a_(world, random, config, node.func_236763_a_(), 3, leaves, -1, node.func_236765_c_(), p_230372_10_);
+        }
+    }
+
+    @Override
+    public int func_230374_a_(Random p_230374_1_, int p_230374_2_, BaseTreeFeatureConfig p_230374_3_) {
+        return 0;
+    }
+
+    @Override
+    protected boolean func_230373_a_(Random random, int dx, int y, int dz, int radius, boolean giantTrunk) {
+        return radius != 0 && dx == radius && dz == radius && random.nextInt(2) == 0;
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/CitrusTrunkPlacer.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/CitrusTrunkPlacer.java
@@ -1,0 +1,108 @@
+package net.tropicraft.core.common.dimension.feature.tree;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.block.RotatedPillarBlock;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MutableBoundingBox;
+import net.minecraft.world.gen.IWorldGenerationReader;
+import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
+import net.minecraft.world.gen.foliageplacer.FoliagePlacer;
+import net.minecraft.world.gen.trunkplacer.AbstractTrunkPlacer;
+import net.minecraft.world.gen.trunkplacer.TrunkPlacerType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+public final class CitrusTrunkPlacer extends AbstractTrunkPlacer {
+    public static final Codec<CitrusTrunkPlacer> CODEC = RecordCodecBuilder.create(instance -> {
+        return getAbstractTrunkCodec(instance)
+                .apply(instance, CitrusTrunkPlacer::new);
+    });
+
+    public CitrusTrunkPlacer(int baseHeight, int heightRandA, int heightRandB) {
+        super(baseHeight, heightRandA, heightRandB);
+    }
+
+    @Override
+    protected TrunkPlacerType<?> getPlacerType() {
+        return TropicraftTrunkPlacers.CITRUS;
+    }
+
+    @Override
+    public List<FoliagePlacer.Foliage> getFoliages(IWorldGenerationReader world, Random random, int height, BlockPos origin, Set<BlockPos> logs, MutableBoundingBox bounds, BaseTreeFeatureConfig config) {
+        ArrayList<FoliagePlacer.Foliage> leafNodes = new ArrayList<>();
+
+        // Set grass to dirt
+        func_236909_a_(world, origin.down());
+
+        // Place trunk
+        for (int i = 0; i < height; ++i) {
+            func_236911_a_(world, random, origin.up(i), logs, bounds, config);
+        }
+
+        // Add center leaf cluster
+        leafNodes.add(new FoliagePlacer.Foliage(origin.up(height - 1), 1, false));
+
+        growBranches(world, random, origin.up(height - 4), logs, bounds, config, leafNodes);
+
+        return leafNodes;
+    }
+
+    private void growBranches(IWorldGenerationReader world, Random random, BlockPos origin, Set<BlockPos> logs, MutableBoundingBox bounds, BaseTreeFeatureConfig config, List<FoliagePlacer.Foliage> leafNodes) {
+        int count = random.nextInt(3) + 1;
+        double thetaOffset = random.nextDouble() * 2 * Math.PI;
+
+        // Place 1-3 branches
+        for (int i = 0; i < count; i++) {
+            // Get angle of this branch
+            double theta = (((double) i / count) * 2 * Math.PI) + thetaOffset;
+
+            // Add a random offset to the theta
+            theta += random.nextDouble() * Math.PI * 0.15;
+
+            // Make branches 3-4 blocks long
+            int dist = random.nextInt(3) == 0 ? 4 : 3;
+
+            for (int j = 1; j <= dist; j++) {
+                int x = (int) (Math.cos(theta) * j);
+                int y = j == dist ? 1 : 0; // Make branch go up
+                int z = (int) (Math.sin(theta) * j);
+                BlockPos local = origin.add(x, y, z);
+
+                // Get axis based on position
+                Direction.Axis axis = getAxis(origin, local);
+
+                // Place branch and add to logs
+                func_236913_a_(world, local, config.trunkProvider.getBlockState(random, local).with(RotatedPillarBlock.AXIS, axis), bounds);
+                logs.add(local);
+
+                // Add leaves around the branch
+                if (j == dist) {
+                    leafNodes.add(new FoliagePlacer.Foliage(local, 0, false));
+                }
+            }
+        }
+    }
+
+    // Lifted from FancyTrunkPlacer#func_236889_a_
+    private Direction.Axis getAxis(BlockPos start, BlockPos end) {
+        Direction.Axis axis = Direction.Axis.Y;
+        int xOffset = Math.abs(end.getX() - start.getX());
+        int zOffst = Math.abs(end.getZ() - start.getZ());
+        int maxOffset = Math.max(xOffset, zOffst);
+
+        if (maxOffset > 0) {
+            if (xOffset == maxOffset) {
+                axis = Direction.Axis.X;
+            } else {
+                axis = Direction.Axis.Z;
+            }
+        }
+
+        return axis;
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/TropicraftFoliagePlacers.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/TropicraftFoliagePlacers.java
@@ -12,6 +12,7 @@ public final class TropicraftFoliagePlacers {
     public static final DeferredRegister<FoliagePlacerType<?>> FOLIAGE_PLACERS = DeferredRegister.create(ForgeRegistries.FOLIAGE_PLACER_TYPES, Constants.MODID);
     public static RegistryObject<FoliagePlacerType<MangroveFoliagePlacer>> MANGROVE = register("mangrove", MangroveFoliagePlacer.CODEC);
     public static RegistryObject<FoliagePlacerType<SmallMangroveFoliagePlacer>> SMALL_MANGROVE = register("small_mangrove", SmallMangroveFoliagePlacer.CODEC);
+    public static RegistryObject<FoliagePlacerType<CitrusFoliagePlacer>> CITRUS = register("citrus", CitrusFoliagePlacer.CODEC);
 
     private static <T extends FoliagePlacer> RegistryObject<FoliagePlacerType<T>> register(String name, Codec<T> codec) {
         return FOLIAGE_PLACERS.register(name, () -> new FoliagePlacerType<>(codec));

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/tree/TropicraftTrunkPlacers.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/tree/TropicraftTrunkPlacers.java
@@ -10,6 +10,7 @@ import net.tropicraft.Constants;
 public final class TropicraftTrunkPlacers {
     public static final TrunkPlacerType<MangroveTrunkPlacer> MANGROVE = register("mangrove", MangroveTrunkPlacer.CODEC);
     public static final TrunkPlacerType<SmallMangroveTrunkPlacer> SMALL_MANGROVE = register("small_mangrove", SmallMangroveTrunkPlacer.CODEC);
+    public static final TrunkPlacerType<CitrusTrunkPlacer> CITRUS = register("citrus", CitrusTrunkPlacer.CODEC);
 
     private static <T extends AbstractTrunkPlacer> TrunkPlacerType<T> register(String name, Codec<T> codec) {
         return Registry.register(Registry.TRUNK_REPLACER, new ResourceLocation(Constants.MODID, name), new TrunkPlacerType<>(codec));


### PR DESCRIPTION
Fruit trees more match real life citrus trees, they have multiple branches and have a wide canopy. As they are taller and larger, their chances have been slightly decreased to account for their size.
Example:
![image](https://user-images.githubusercontent.com/25208576/129266931-0b6c9620-64bc-4752-af7f-de9f39fb607a.png)
