### PR TITLE
Fixed beach float camera controller

### DIFF
--- a/src/main/java/net/tropicraft/core/common/entity/placeable/BeachFloatEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/placeable/BeachFloatEntity.java
@@ -250,13 +250,15 @@ public class BeachFloatEntity extends FurnitureEntity implements IEntityAddition
         if (!entityToUpdate.level.isClientSide || isClientFirstPerson(entityToUpdate)) {
             entityToUpdate.setYBodyRot(this.getYRot());
             float yaw = Mth.wrapDegrees(entityToUpdate.getYRot() - this.getYRot());
-            float pitch = Mth.wrapDegrees(entityToUpdate.getYRot() - this.getYRot());
+            float pitch = Mth.wrapDegrees(entityToUpdate.getXRot() - this.getXRot());
             float clampedYaw = Mth.clamp(yaw, -105.0F, 105.0F);
-            float clampedPitch = Mth.clamp(pitch, -100F, -10F);
-            entityToUpdate.yRotO += clampedYaw - yaw;
-            entityToUpdate.setYRot(entityToUpdate.getYRot() + clampedYaw - yaw);
-            entityToUpdate.xRotO += clampedPitch - pitch;
-            entityToUpdate.setXRot(entityToUpdate.getXRot() + clampedPitch - pitch);
+            float clampedPitch = Mth.clamp(pitch, -100F, 0F);
+            float yawClampDelta = clampedYaw - yaw;
+            float pitchClampDelta = clampedPitch - pitch;
+            entityToUpdate.yRotO += yawClampDelta;
+            entityToUpdate.setYRot(entityToUpdate.getYRot() + yawClampDelta);
+            entityToUpdate.xRotO += pitchClampDelta;
+            entityToUpdate.setXRot(entityToUpdate.getXRot() + pitchClampDelta);
             entityToUpdate.setYHeadRot(entityToUpdate.getYRot());
         }
     }


### PR DESCRIPTION
Hi,

I fixed the problems described in issue #447, notably the beach float entity camera controller being glitchy, and the camera moving while the player opened their inventory.

The bug lied in code that was copy-pasted not being changed from the Y component to the X component. I spent hours missing the issue because my eyes kept glazing over a Y that was supposed to be an X. Nevertheless, the beach float camera works well now.

Feel free to test the changes and merge. Thanks! 

EDIT: I didn't notice there was a third checkbox regarding the nametag being invisible to other players. That has not been solved yet.