### PR TITLE
Fixed Man O War death message

### DIFF
--- a/src/main/java/net/tropicraft/core/common/entity/underdasea/ManOWarEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/underdasea/ManOWarEntity.java
@@ -119,8 +119,7 @@ public class ManOWarEntity extends WaterAnimal {
                 for (LivingEntity ent : list) {
                     if (ent.getType() != TropicraftEntities.MAN_O_WAR.get()) {
                         if (ent.isInWater()) {
-                            // TODO change so death msg isn't "struck by lightning"
-                            ent.hurt(DamageSource.LIGHTNING_BOLT, (float) getAttribute(Attributes.ATTACK_DAMAGE).getValue());
+                            ent.hurt(DamageSource.mobAttack(this), (float) getAttribute(Attributes.ATTACK_DAMAGE).getValue());
                             attackTimer = 20;
                         }
                     }


### PR DESCRIPTION
Hi,

This is a very simple fix for issue #455.
It said prior to this fix: `Player was struck by lightning`.
After this fix it says: `Player was slain by Man o' War`.

I'm not sure why LIGHTNING_BOLT was used as the DamageSource, especially because there is a TODO that acknowledges that it is incorrect. Nevertheless, the new changes reflect how the death message should have been all along.

Thanks for taking the time to read this PR. Feel free to merge after testing locally!