### PR TITLE
Fixed bamboo item frame creative drops

### DIFF
--- a/src/main/java/net/tropicraft/core/common/entity/BambooItemFrame.java
+++ b/src/main/java/net/tropicraft/core/common/entity/BambooItemFrame.java
@@ -32,12 +32,7 @@ public class BambooItemFrame extends ItemFrame implements IEntityAdditionalSpawn
     }
     
     @Override
-    protected void dropItem(Entity entityIn, boolean dropSelf) {
-        super.dropItem(entityIn, false);
-        if (dropSelf) {
-            this.spawnAtLocation(TropicraftItems.BAMBOO_ITEM_FRAME.get());
-        }
-    }
+    public ItemStack getFrameItemStack() { return new ItemStack(TropicraftItems.BAMBOO_ITEM_FRAME.get()); }
 
     @Override
     public Packet<?> getAddEntityPacket() {


### PR DESCRIPTION
Hi,

In this PR I addressed issue #453 regarding bamboo item frames dropping when broken in creative mode. I took a page from how the glow item frame overrides the ItemStack dropped from a regular item frame to a glow item frame, in which the getFrameItemStack() method is overridden. I have overridden this method also and I return an ItemStack constructed from the BAMBOO_ITEM_FRAME registry entry. This allows the inherited code from Vanilla to work its magic and we don't have to write any item dropping code since it is now handled by the code in ItemFrame, from whom BambooItemFrame inherits from.

The Vanilla code has a check in it that makes sure the user isn't in creative mode (it actually checks whether or not the player has the instabuild ability but that is functionally the same thing as checking if the user is in creative mode).

I removed the legacy item dropping code and in its place we override getFrameItemStack(). We now get Vanilla ItemFrame behavior!

Thank you for taking the time to read this pull request. Feel free to test and merge into master!