### PR TITLE
Fixed bamboo door occlusion

### DIFF
--- a/src/main/java/net/tropicraft/core/common/block/TropicraftBlocks.java
+++ b/src/main/java/net/tropicraft/core/common/block/TropicraftBlocks.java
@@ -196,7 +196,7 @@ public class TropicraftBlocks {
     public static final RegistryObject<WallBlock> CHUNK_WALL = register("chunk_wall", Builder.wall(CHUNK));
     
     public static final RegistryObject<DoorBlock> BAMBOO_DOOR = register(
-            "bamboo_door", () -> new DoorBlock(Block.Properties.copy(BAMBOO_BUNDLE.get()).strength(1.0F)) {});
+            "bamboo_door", () -> new DoorBlock(Block.Properties.copy(BAMBOO_BUNDLE.get()).strength(1.0F).noOcclusion()) {});
     public static final RegistryObject<DoorBlock> PALM_DOOR = register(
             "palm_door", () -> new DoorBlock(Block.Properties.copy(Blocks.OAK_DOOR)) {});
     public static final RegistryObject<DoorBlock> MAHOGANY_DOOR = register(
@@ -205,7 +205,7 @@ public class TropicraftBlocks {
             "thatch_door", () -> new DoorBlock(Block.Properties.copy(THATCH_BUNDLE.get())) {});
     
     public static final RegistryObject<TrapDoorBlock> BAMBOO_TRAPDOOR = register(
-            "bamboo_trapdoor", () -> new TrapDoorBlock(Block.Properties.copy(BAMBOO_DOOR.get()).noOcclusion()) {});
+            "bamboo_trapdoor", () -> new TrapDoorBlock(Block.Properties.copy(BAMBOO_DOOR.get())) {});
     public static final RegistryObject<TrapDoorBlock> PALM_TRAPDOOR = register(
             "palm_trapdoor", () -> new TrapDoorBlock(Block.Properties.copy(PALM_DOOR.get())) {});
     public static final RegistryObject<TrapDoorBlock> MAHOGANY_TRAPDOOR = register(


### PR DESCRIPTION
Hi,

In this pull request I resolved issue #452 regarding the fact that bamboo doors allowed you to see through the world because the adjacent block faces were culled from the chunk mesh. I resolved this by adding the noOcclusion block property which was already present on bamboo trapdoors. I removed the property from bamboo trapdoors, since their properties are copied from that of bamboo doors and setting that property again would be redundant.

This has to be done for bamboo doors and trapdoors because they have transparent pixels in their texture, meaning that if no block faces are added to the chunk mesh for adjacent blocks, you will be able to see through the world since part of the texture is transparent.

Thank you for taking the time to read my pull request. Feel free to test my changes and merge into master!