### PR TITLE
Added recipe for sand from purified sand

### DIFF
--- a/src/generated/resources/data/tropicraft/recipes/sand_from_purified_sand.json
+++ b/src/generated/resources/data/tropicraft/recipes/sand_from_purified_sand.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "SSS",
+    "SDS",
+    "SSS"
+  ],
+  "key": {
+    "S": {
+      "item": "tropicraft:purified_sand"
+    },
+    "D": {
+      "item": "minecraft:dirt"
+    }
+  },
+  "result": {
+    "item": "minecraft:sand",
+    "count": 8
+  }
+}


### PR DESCRIPTION
Hi,

This pull request solves issue #426. I have added a recipe for vanilla sand from purified sand.

Recipe shape:
```
SSS
SDS
SSS
```

This recipe results in 8 sand.

Perhaps I should add a recipe for purified sand from regular sand? What are your thoughts on this?

Thank you for reading this pull request. Feel free to test and merge into master!