### PR TITLE
Fixed Tropicreeper appearing to hover

### DIFF
--- a/src/main/java/net/tropicraft/core/client/entity/model/TropiCreeperModel.java
+++ b/src/main/java/net/tropicraft/core/client/entity/model/TropiCreeperModel.java
@@ -102,22 +102,22 @@ public class TropiCreeperModel extends ListModel<TropiCreeperEntity> {
 
         modelPartData.addOrReplaceChild("leg3",
                 CubeListBuilder.create().texOffs(0, 16)
-                        .addBox(-2F, 0.0F, -2F, 4, 6, 4),
+                        .addBox(-2F, 2F, -2F, 4, 6, 4),
                 PartPose.offset(-2F, 12 + i, -4F));
 
         modelPartData.addOrReplaceChild("leg4",
                 CubeListBuilder.create().texOffs(0, 16)
-                        .addBox(-2F, 0.0F, -2F, 4, 6, 4),
+                        .addBox(-2F, 2F, -2F, 4, 6, 4),
                 PartPose.offset(2.0F, 12 + i, -4F));
 
         modelPartData.addOrReplaceChild("leg1",
                 CubeListBuilder.create().texOffs(0, 16)
-                        .addBox(-2F, 0.0F, -2F, 4, 6, 4),
+                        .addBox(-2F, 2F, -2F, 4, 6, 4),
                 PartPose.offset(-2F, 12 + i, 4F));
 
         modelPartData.addOrReplaceChild("leg2",
                 CubeListBuilder.create().texOffs(0, 16)
-                        .addBox(-2F, 0.0F, -2F, 4, 6, 4),
+                        .addBox(-2F, 2F, -2F, 4, 6, 4),
                 PartPose.offset(2.0F, 12 + i, 4F));
 
         modelPartHead.addOrReplaceChild("hat1",


### PR DESCRIPTION
Hi,

This pull request resolves tropicreepers appearing to hover. I noticed this while testing in my world. Tropicreepers no longer appear to hover after this commit. The issue was that the tropicreeper's legs were too high. If you compare the old tropicreeper model (pre PR) to a regular creeper you can see how the regular creeper's legs were lower. This has been fixed on the tropicreeper. He no longer hovers. I didn't bother to create an issue since I knew I could fix it right away.

Thank you for reading this pull request! Feel free to test and merge into master!