### PR TITLE
Fix incorrect tree being part of rainforest_tree feature

### DIFF
--- a/src/generated/resources/data/tropicraft/worldgen/configured_feature/rainforest_tree.json
+++ b/src/generated/resources/data/tropicraft/worldgen/configured_feature/rainforest_tree.json
@@ -11,7 +11,7 @@
         "placement": []
       },
       {
-        "feature": "tropicraft:large_palm_tree",
+        "feature": "tropicraft:rainforest_large_tualung",
         "placement": []
       },
       {

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/TropicraftTreeFeatures.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/TropicraftTreeFeatures.java
@@ -123,7 +123,7 @@ public final class TropicraftTreeFeatures {
         register(context, RAINFOREST_SMALL_TUALUNG, TropicraftFeatures.SMALL_TUALUNG);
         register(context, RAINFOREST_LARGE_TUALUNG, TropicraftFeatures.LARGE_TUALUNG);
         register(context, RAINFOREST_TALL_TREE, TropicraftFeatures.TALL_TREE);
-        registerRandom(context, RAINFOREST_TREE, RAINFOREST_UP_TREE, RAINFOREST_SMALL_TUALUNG, LARGE_PALM_TREE, RAINFOREST_TALL_TREE);
+        registerRandom(context, RAINFOREST_TREE, RAINFOREST_UP_TREE, RAINFOREST_SMALL_TUALUNG, RAINFOREST_LARGE_TUALUNG, RAINFOREST_TALL_TREE);
 
         register(context, PLEODENDRON, Feature.TREE, new TreeConfiguration.TreeConfigurationBuilder(
                 BlockStateProvider.simple(Blocks.JUNGLE_LOG.defaultBlockState()),


### PR DESCRIPTION
Fixes #625

The issue was that the palm tree was added to the configured feature and not the tualung ¯\_(ツ)_/¯ 