### PR TITLE
fixed failgull speed sometime too fast when touch ground

### DIFF
--- a/src/main/java/net/tropicraft/core/common/entity/passive/FailgullEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/passive/FailgullEntity.java
@@ -52,7 +52,7 @@ public class FailgullEntity extends Animal implements FlyingAnimal {
     public static AttributeSupplier.Builder createAttributes() {
         return Animal.createMobAttributes()
                 .add(Attributes.MAX_HEALTH, 3.0)
-                .add(Attributes.MOVEMENT_SPEED, 0.6)
+                .add(Attributes.MOVEMENT_SPEED, 0.3)
                 .add(Attributes.FLYING_SPEED, 0.9)
                 .add(Attributes.FOLLOW_RANGE, 12.0);
     }


### PR DESCRIPTION
This problem is The movement speed attribute is too high when touching the ground, causing collisions to occur quickly.
Therefore, I have corrected the movement speed attribute to an appropriate number.