### PR TITLE
Fix: Prevent placeColumn from overwriting the Volcano block

### DIFF
--- a/src/main/java/net/tropicraft/core/common/dimension/feature/volcano/VolcanoStructurePiece.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/volcano/VolcanoStructurePiece.java
@@ -108,7 +108,7 @@ public class VolcanoStructurePiece extends StructurePiece {
 
         BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
 
-        for (int y = level.getMaxBuildHeight(); y > level.getMinBuildHeight(); y--) {
+        for (int y = level.getMaxBuildHeight(); y > level.getMinBuildHeight() + 2; y--) {
             mutablePos.set(x, y, z);
 
             if (height + terrainY < calderaCutoffY) {


### PR DESCRIPTION
.../block entity that keeps eruption state. 

The VOLCANO block is placed at y=level.getMinBuildHeight()+1

Then placeColumn starts placing blocks inside the bounding box between maxBuildHeight and minBuildHeight. This ends up calling setBlock on the VOLCANO block position, which blows away the block and the associated entity that handles volcano ticking.

This change makes placeColumn stop at minBuildHeight +2 so that the VOLCANO block is preserved.

(Eruptions are still broken because TropicraftEntities.LAVA_BALL is null, but if throwing lava is disabled, everything else about eruptions works. And eruptions are still hardocoded off in the config.)