### PR TITLE
Fix/re-implement eruptions.

### DIFF
--- a/src/main/java/net/tropicraft/Tropicraft.java
+++ b/src/main/java/net/tropicraft/Tropicraft.java
@@ -79,6 +79,7 @@ import net.tropicraft.core.common.item.TropicraftDataComponents;
 import net.tropicraft.core.common.item.TropicraftItems;
 import net.tropicraft.core.common.item.scuba.ScubaData;
 import net.tropicraft.core.common.item.scuba.ScubaGogglesItem;
+import net.tropicraft.core.common.particle.TropicraftParticles;
 import net.tropicraft.core.common.sound.Sounds;
 
 import java.util.function.Supplier;
@@ -141,6 +142,7 @@ public class Tropicraft {
         TropicraftDataComponents.REGISTER.register(modBus);
         TropicraftArmorMaterials.REGISTER.register(modBus);
         TropicraftDrinkActions.REGISTER.register(modBus);
+        TropicraftParticles.PARTICLE_TYPES.register(modBus);
 
         IModFile modFile = container.getModInfo().getOwningFile().getFile();
         modBus.addListener((AddPackFindersEvent event) -> {

--- a/src/main/java/net/tropicraft/core/client/TropicraftRenderLayers.java
+++ b/src/main/java/net/tropicraft/core/client/TropicraftRenderLayers.java
@@ -10,49 +10,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 import net.tropicraft.Tropicraft;
-import net.tropicraft.core.client.entity.model.AshenModel;
-import net.tropicraft.core.client.entity.model.BambooMugModel;
-import net.tropicraft.core.client.entity.model.BasiliskLizardModel;
-import net.tropicraft.core.client.entity.model.BeachFloatModel;
-import net.tropicraft.core.client.entity.model.ChairModel;
-import net.tropicraft.core.client.entity.model.CuberaModel;
-import net.tropicraft.core.client.entity.model.EIHMachineModel;
-import net.tropicraft.core.client.entity.model.EIHModel;
-import net.tropicraft.core.client.entity.model.EagleRayModel;
-import net.tropicraft.core.client.entity.model.EggModel;
-import net.tropicraft.core.client.entity.model.FailgullModel;
-import net.tropicraft.core.client.entity.model.FiddlerCrabModel;
-import net.tropicraft.core.client.entity.model.GibnutModel;
-import net.tropicraft.core.client.entity.model.HummingbirdModel;
-import net.tropicraft.core.client.entity.model.IguanaModel;
-import net.tropicraft.core.client.entity.model.JaguarModel;
-import net.tropicraft.core.client.entity.model.KoaModel;
-import net.tropicraft.core.client.entity.model.ManOWarModel;
-import net.tropicraft.core.client.entity.model.ManateeModel;
-import net.tropicraft.core.client.entity.model.MarlinModel;
-import net.tropicraft.core.client.entity.model.PapyrusCanaryModel;
-import net.tropicraft.core.client.entity.model.PapyrusGonolekModel;
-import net.tropicraft.core.client.entity.model.PlayerHeadpieceModel;
-import net.tropicraft.core.client.entity.model.SeaTurtleModel;
-import net.tropicraft.core.client.entity.model.SeaUrchinModel;
-import net.tropicraft.core.client.entity.model.SeahorseModel;
-import net.tropicraft.core.client.entity.model.SharkModel;
-import net.tropicraft.core.client.entity.model.ShoebillStorkModel;
-import net.tropicraft.core.client.entity.model.SlenderHarvestMouseModel;
-import net.tropicraft.core.client.entity.model.SpiderMonkeyModel;
-import net.tropicraft.core.client.entity.model.TapirModel;
-import net.tropicraft.core.client.entity.model.ToucanModel;
-import net.tropicraft.core.client.entity.model.TreeFrogModel;
-import net.tropicraft.core.client.entity.model.TropiBeeModel;
-import net.tropicraft.core.client.entity.model.TropiCreeperModel;
-import net.tropicraft.core.client.entity.model.TropiSkellyModel;
-import net.tropicraft.core.client.entity.model.TropicraftDolphinModel;
-import net.tropicraft.core.client.entity.model.TropicraftFishModel;
-import net.tropicraft.core.client.entity.model.UmbrellaModel;
-import net.tropicraft.core.client.entity.model.VMonkeyModel;
-import net.tropicraft.core.client.entity.model.WhiteCollaredOlivebackModel;
-import net.tropicraft.core.client.entity.model.WhiteLippedPeccaryModel;
-import net.tropicraft.core.client.entity.model.WhiteWingedWarblerModel;
+import net.tropicraft.core.client.entity.model.*;
 import net.tropicraft.core.client.scuba.ModelScubaGear;
 
 import java.util.function.Supplier;
@@ -113,6 +71,7 @@ public class TropicraftRenderLayers {
     public static ModelLayerLocation SHOEBILL_STORK_LAYER;
     public static ModelLayerLocation WHITE_COLLARED_OLIVEBACK_LAYER;
     public static ModelLayerLocation WHITE_WINGED_WARBLER_LAYER;
+    public static ModelLayerLocation LAVA_BALL_LAYER;
 
     // Scuba
     public static ModelLayerLocation CHEST_SCUBA_LAYER;
@@ -177,6 +136,7 @@ public class TropicraftRenderLayers {
 		SHOEBILL_STORK_LAYER = registerMain("shoebill_stork", ShoebillStorkModel::createBodyLayer, event);
 		WHITE_COLLARED_OLIVEBACK_LAYER = registerMain("white_collared_oliveback", WhiteCollaredOlivebackModel::createBodyLayer, event);
 		WHITE_WINGED_WARBLER_LAYER = registerMain("white_winged_warbler", WhiteWingedWarblerModel::createBodyLayer, event);
+        LAVA_BALL_LAYER = registerMain("lava_ball", LavaBallModel::create, event);
 
         HEADPIECE_LAYER = registerMain("headpiece", PlayerHeadpieceModel::create, event);
         HEAD_SCUBA_LAYER = registerMain("scuba_goggles", ModelScubaGear::create, event);

--- a/src/main/java/net/tropicraft/core/client/entity/model/LavaBallModel.java
+++ b/src/main/java/net/tropicraft/core/client/entity/model/LavaBallModel.java
@@ -1,0 +1,72 @@
+package net.tropicraft.core.client.entity.model;
+
+import net.minecraft.client.model.ListModel;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.tropicraft.core.common.entity.projectile.LavaBallEntity;
+
+import java.util.List;
+
+public class LavaBallModel extends ListModel<LavaBallEntity> {
+
+    private final ModelPart base;
+    private final ModelPart top;
+    private final ModelPart front;
+    private final ModelPart left;
+    private final ModelPart back;
+    private final ModelPart right;
+    private final ModelPart bottom;
+
+
+    public LavaBallModel(ModelPart root) {
+        base = root.getChild("base");
+        top = root.getChild("top");
+        front = root.getChild("front");
+        left = root.getChild("left");
+        back = root.getChild("back");
+        right = root.getChild("right");
+        bottom = root.getChild("bottom");
+    }
+
+    public static LayerDefinition create() {
+        MeshDefinition mesh = new MeshDefinition();
+        PartDefinition root = mesh.getRoot();
+
+        root.addOrReplaceChild("base", CubeListBuilder.create().mirror().texOffs(0, 0).addBox(-3.0f, 16.0f, -3.0f, 6,
+                6, 6), PartPose.offset(0.0f, 0.0f, 0.0f));
+
+        root.addOrReplaceChild("top", CubeListBuilder.create().mirror().texOffs(0, 38).addBox(-2.0f, 15.0f, -2.0f, 4,
+                1, 4), PartPose.offset(0.0f, 0.0f, 0.0f));
+
+        root.addOrReplaceChild("front", CubeListBuilder.create().mirror().texOffs(0, 12).addBox(-2.0f, 17.0f, -4.0f,
+                4, 4, 1), PartPose.offset(0.0f, 0.0f, 0.0f));
+
+        root.addOrReplaceChild("left", CubeListBuilder.create().mirror().texOffs(0, 17).addBox(3.0f, 17.0f, -2.0f, 1,
+                4, 4), PartPose.offset(0.0f, 0.0f, 0.0f));
+
+        root.addOrReplaceChild("back", CubeListBuilder.create().mirror().texOffs(0, 25).addBox(-2.0f, 17.0f, 3.0f, 4,
+                4, 1), PartPose.offset(0.0f, 0.0f, 0.0f));
+
+        root.addOrReplaceChild("right", CubeListBuilder.create().mirror().texOffs(0, 30).addBox(-4.0f, 17.0f, -2.0f,
+                1, 4, 4), PartPose.offset(0.0f, 0.0f, 0.0f));
+
+        root.addOrReplaceChild("bottom", CubeListBuilder.create().mirror().texOffs(0, 38).addBox(-2.0f, 22.0f, -2.0f,
+                4, 1, 4), PartPose.offset(0.0f, 0.0f, 0.0f));
+
+        return LayerDefinition.create(mesh, 32, 64);
+    }
+
+    @Override
+    public Iterable<ModelPart> parts() {
+        return List.of(base, top, front, left, back, right, bottom);
+    }
+
+    @Override
+    public void setupAnim(LavaBallEntity entity, float limbSwing, float limbSwingAmount, float ageInTicks,
+                          float netHeadYaw, float headPitch) {
+    }
+}

--- a/src/main/java/net/tropicraft/core/client/entity/model/LavaBallModel.java
+++ b/src/main/java/net/tropicraft/core/client/entity/model/LavaBallModel.java
@@ -3,10 +3,7 @@ package net.tropicraft.core.client.entity.model;
 import net.minecraft.client.model.ListModel;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.model.geom.PartPose;
-import net.minecraft.client.model.geom.builders.CubeListBuilder;
-import net.minecraft.client.model.geom.builders.LayerDefinition;
-import net.minecraft.client.model.geom.builders.MeshDefinition;
-import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.minecraft.client.model.geom.builders.*;
 import net.tropicraft.core.common.entity.projectile.LavaBallEntity;
 
 import java.util.List;
@@ -37,27 +34,27 @@ public class LavaBallModel extends ListModel<LavaBallEntity> {
         PartDefinition root = mesh.getRoot();
 
         root.addOrReplaceChild("base", CubeListBuilder.create().mirror().texOffs(0, 0).addBox(-3.0f, 16.0f, -3.0f, 6,
-                6, 6), PartPose.offset(0.0f, 0.0f, 0.0f));
+                6, 6, CubeDeformation.NONE,0.5f,0.5f), PartPose.offset(0.0f, 0.0f, 0.0f));
 
-        root.addOrReplaceChild("top", CubeListBuilder.create().mirror().texOffs(0, 38).addBox(-2.0f, 15.0f, -2.0f, 4,
-                1, 4), PartPose.offset(0.0f, 0.0f, 0.0f));
+        root.addOrReplaceChild("top", CubeListBuilder.create().mirror().texOffs(0, 0).addBox(-2.0f, 15.0f, -2.0f, 4,
+                1, 4,CubeDeformation.NONE,0.5f,0.5f), PartPose.offset(0.0f, 0.0f, 0.0f));
 
-        root.addOrReplaceChild("front", CubeListBuilder.create().mirror().texOffs(0, 12).addBox(-2.0f, 17.0f, -4.0f,
-                4, 4, 1), PartPose.offset(0.0f, 0.0f, 0.0f));
+        root.addOrReplaceChild("front", CubeListBuilder.create().mirror().texOffs(0, 0).addBox(-2.0f, 17.0f, -4.0f,
+                4, 4, 1,CubeDeformation.NONE,0.5f,0.5f), PartPose.offset(0.0f, 0.0f, 0.0f));
 
-        root.addOrReplaceChild("left", CubeListBuilder.create().mirror().texOffs(0, 17).addBox(3.0f, 17.0f, -2.0f, 1,
-                4, 4), PartPose.offset(0.0f, 0.0f, 0.0f));
+        root.addOrReplaceChild("left", CubeListBuilder.create().mirror().texOffs(0, 0).addBox(3.0f, 17.0f, -2.0f, 1,
+                4, 4,CubeDeformation.NONE,0.5f,0.5f), PartPose.offset(0.0f, 0.0f, 0.0f));
 
-        root.addOrReplaceChild("back", CubeListBuilder.create().mirror().texOffs(0, 25).addBox(-2.0f, 17.0f, 3.0f, 4,
-                4, 1), PartPose.offset(0.0f, 0.0f, 0.0f));
+        root.addOrReplaceChild("back", CubeListBuilder.create().mirror().texOffs(0, 0).addBox(-2.0f, 17.0f, 3.0f, 4,
+                4, 1,CubeDeformation.NONE,0.5f,0.5f), PartPose.offset(0.0f, 0.0f, 0.0f));
 
-        root.addOrReplaceChild("right", CubeListBuilder.create().mirror().texOffs(0, 30).addBox(-4.0f, 17.0f, -2.0f,
-                1, 4, 4), PartPose.offset(0.0f, 0.0f, 0.0f));
+        root.addOrReplaceChild("right", CubeListBuilder.create().mirror().texOffs(0, 0).addBox(-4.0f, 17.0f, -2.0f,
+                1, 4, 4,CubeDeformation.NONE,0.5f,0.5f), PartPose.offset(0.0f, 0.0f, 0.0f));
 
-        root.addOrReplaceChild("bottom", CubeListBuilder.create().mirror().texOffs(0, 38).addBox(-2.0f, 22.0f, -2.0f,
-                4, 1, 4), PartPose.offset(0.0f, 0.0f, 0.0f));
+        root.addOrReplaceChild("bottom", CubeListBuilder.create().mirror().texOffs(0, 0).addBox(-2.0f, 22.0f, -2.0f,
+                4, 1, 4,CubeDeformation.NONE,0.5f,0.5f), PartPose.offset(0.0f, 0.0f, 0.0f));
 
-        return LayerDefinition.create(mesh, 32, 64);
+        return LayerDefinition.create(mesh, 32, 32);
     }
 
     @Override

--- a/src/main/java/net/tropicraft/core/client/entity/render/LavaBallRenderer.java
+++ b/src/main/java/net/tropicraft/core/client/entity/render/LavaBallRenderer.java
@@ -10,13 +10,13 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.tropicraft.Tropicraft;
 import net.tropicraft.core.client.TropicraftRenderLayers;
 import net.tropicraft.core.client.entity.model.LavaBallModel;
 import net.tropicraft.core.common.entity.projectile.LavaBallEntity;
 
 public class LavaBallRenderer extends EntityRenderer<LavaBallEntity> {
-    public static final ResourceLocation LAVA_BALL_TEXTURE = Tropicraft.location("textures/entity/lavaball.png");
+    public static final ResourceLocation LAVA_BALL_TEXTURE = ResourceLocation.withDefaultNamespace("textures/block" +
+            "/lava_flow.png");
     private final EntityModel<LavaBallEntity> model;
 
     public LavaBallRenderer(EntityRendererProvider.Context context) {

--- a/src/main/java/net/tropicraft/core/client/entity/render/LavaBallRenderer.java
+++ b/src/main/java/net/tropicraft/core/client/entity/render/LavaBallRenderer.java
@@ -27,7 +27,7 @@ public class LavaBallRenderer extends EntityRenderer<LavaBallEntity> {
     public void render(LavaBallEntity lavaBall, float entityYaw, float partialTicks, PoseStack stack,
                        MultiBufferSource buffer, int packedLightIn) {
         stack.pushPose();
-        stack.scale(1.5f, 1.5f, 1.5f);
+        stack.scale(2, 2f, 2f);
         stack.translate(0, -0.875, 0);
         stack.mulPose(Axis.YP.rotationDegrees(180 - entityYaw));
         VertexConsumer builder = buffer.getBuffer(model.renderType(LAVA_BALL_TEXTURE));

--- a/src/main/java/net/tropicraft/core/client/entity/render/LavaBallRenderer.java
+++ b/src/main/java/net/tropicraft/core/client/entity/render/LavaBallRenderer.java
@@ -1,0 +1,49 @@
+package net.tropicraft.core.client.entity.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Axis;
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.tropicraft.Tropicraft;
+import net.tropicraft.core.client.TropicraftRenderLayers;
+import net.tropicraft.core.client.entity.model.LavaBallModel;
+import net.tropicraft.core.common.entity.projectile.LavaBallEntity;
+
+public class LavaBallRenderer extends EntityRenderer<LavaBallEntity> {
+    public static final ResourceLocation LAVA_BALL_TEXTURE = Tropicraft.location("textures/entity/lavaball.png");
+    private final EntityModel<LavaBallEntity> model;
+
+    public LavaBallRenderer(EntityRendererProvider.Context context) {
+        super(context);
+        this.model = new LavaBallModel(context.bakeLayer(TropicraftRenderLayers.LAVA_BALL_LAYER));
+    }
+
+    public void render(LavaBallEntity lavaBall, float entityYaw, float partialTicks, PoseStack stack,
+                       MultiBufferSource buffer, int packedLightIn) {
+        stack.pushPose();
+        stack.scale(1.5f, 1.5f, 1.5f);
+        stack.translate(0, -0.875, 0);
+        stack.mulPose(Axis.YP.rotationDegrees(180 - entityYaw));
+        VertexConsumer builder = buffer.getBuffer(model.renderType(LAVA_BALL_TEXTURE));
+        model.renderToBuffer(stack, builder, getPackedLightCoords(lavaBall, partialTicks), OverlayTexture.NO_OVERLAY);
+        super.render(lavaBall, entityYaw, partialTicks, stack, buffer, packedLightIn);
+        stack.popPose();
+    }
+
+    //Light level is always max, cuz it's lava!
+    @Override
+    protected int getBlockLightLevel(LavaBallEntity entity, BlockPos pos) {
+        return 15;
+    }
+
+    @Override
+    public ResourceLocation getTextureLocation(LavaBallEntity entity) {
+        return LAVA_BALL_TEXTURE;
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/TropicsConfigs.java
+++ b/src/main/java/net/tropicraft/core/common/TropicsConfigs.java
@@ -4,12 +4,11 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class TropicsConfigs {
-    public static final boolean allowVolcanoEruption = false;
-
     public static final ModConfigSpec COMMON_SPEC;
     public static final Common COMMON;
 
     public static class Common {
+        public final ModConfigSpec.ConfigValue<Boolean> allowVolcanoEruption;
         public final ModConfigSpec.ConfigValue<Boolean> allowExplodingCoconutsByNonOPs;
         public final ModConfigSpec.ConfigValue<Boolean> spawnHostileMobsInTropics;
 
@@ -26,6 +25,11 @@ public class TropicsConfigs {
                     .translation("config.tropicraft.common.mobs.allow_hostiles")
                     .define("Should hostile mobs spawn in the Tropics dimension?", false);
             builder.pop();
+            builder.push("Worldgen");
+            allowVolcanoEruption = builder
+                    .comment("Should volcanoes erupt periodically?")
+                    .translation("config.tropicraft.common.worldgen.allow_volcano_eruption")
+                    .define("Should volcanoes erupt periodically, spilling lava and flinging lava balls?", false);
         }
     }
 

--- a/src/main/java/net/tropicraft/core/common/block/CoolingLavaBlock.java
+++ b/src/main/java/net/tropicraft/core/common/block/CoolingLavaBlock.java
@@ -1,0 +1,46 @@
+package net.tropicraft.core.common.block;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FlowingFluid;
+import net.tropicraft.core.common.block.tileentity.CoolingLavaBlockEntity;
+
+import javax.annotation.Nullable;
+
+public class CoolingLavaBlock extends LiquidBlock implements EntityBlock {
+    public static final MapCodec<LiquidBlock> CODEC = LiquidBlock.CODEC;
+
+    public CoolingLavaBlock(FlowingFluid fluid, Properties properties) {
+        super(fluid, properties);
+    }
+
+    protected static <E extends BlockEntity, A extends BlockEntity> BlockEntityTicker<A> createTickerHelper(BlockEntityType<A> serverType, BlockEntityType<E> clientType, BlockEntityTicker<? super E> ticker) {
+        return clientType == serverType ? (BlockEntityTicker<A>) ticker : null;
+    }
+
+    @Override
+    public MapCodec<LiquidBlock> codec() {
+        return CODEC;
+    }
+
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state,
+                                                                  BlockEntityType<T> type) {
+        return createTickerHelper(type, TropicraftBlocks.COOLING_LAVA_ENTITY.get(),
+                CoolingLavaBlockEntity::coolingLavaTick);
+    }
+
+    @Nullable
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new CoolingLavaBlockEntity(TropicraftBlocks.COOLING_LAVA_ENTITY.get(), pos, state);
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/block/TropicraftBlocks.java
+++ b/src/main/java/net/tropicraft/core/common/block/TropicraftBlocks.java
@@ -129,11 +129,7 @@ import net.tropicraft.core.common.TropicraftTags;
 import net.tropicraft.core.common.block.TikiTorchBlock.TorchSection;
 import net.tropicraft.core.common.block.huge_plant.HugePlantBlock;
 import net.tropicraft.core.common.block.jigarbov.JigarbovTorchType;
-import net.tropicraft.core.common.block.tileentity.AirCompressorBlockEntity;
-import net.tropicraft.core.common.block.tileentity.BambooChestBlockEntity;
-import net.tropicraft.core.common.block.tileentity.DrinkMixerBlockEntity;
-import net.tropicraft.core.common.block.tileentity.SifterBlockEntity;
-import net.tropicraft.core.common.block.tileentity.VolcanoBlockEntity;
+import net.tropicraft.core.common.block.tileentity.*;
 import net.tropicraft.core.common.item.TropicraftItems;
 import net.tropicraft.core.mixin.BlockEntityTypeAccessor;
 import org.apache.commons.lang3.ArrayUtils;
@@ -562,6 +558,12 @@ public class TropicraftBlocks {
             .register();
     public static final BlockEntry<SlabBlock> CHUNK_SLAB = stoneSlab("chunk_slab", CHUNK).register();
     public static final BlockEntry<SlabBlock> PALM_SLAB = woodenSlab("palm_slab", PALM_PLANKS).register();
+
+    public static final BlockEntry<CoolingLavaBlock> COOLING_LAVA = REGISTRATE.block("cooling_lava",
+     p -> new CoolingLavaBlock(Fluids.LAVA, p)).initialProperties(() -> Blocks.LAVA).blockstate((ctx, prov) -> prov.simpleBlock(ctx.get(), prov.models().getExistingFile(prov.mcLoc("block/lava")))).simpleBlockEntity(CoolingLavaBlockEntity::new).register();
+    public static final BlockEntityEntry<CoolingLavaBlockEntity> COOLING_LAVA_ENTITY =
+     BlockEntityEntry.cast(COOLING_LAVA.getSibling(Registries.BLOCK_ENTITY_TYPE));
+
     public static final BlockEntry<SlabBlock> MAHOGANY_SLAB = woodenSlab("mahogany_slab", MAHOGANY_PLANKS).register();
 
     public static final BlockEntry<SaplingBlock> GRAPEFRUIT_SAPLING = sapling("grapefruit_sapling", TropicraftTreeGrowers.GRAPEFRUIT).register();

--- a/src/main/java/net/tropicraft/core/common/block/tileentity/CoolingLavaBlockEntity.java
+++ b/src/main/java/net/tropicraft/core/common/block/tileentity/CoolingLavaBlockEntity.java
@@ -1,0 +1,29 @@
+package net.tropicraft.core.common.block.tileentity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class CoolingLavaBlockEntity extends BlockEntity {
+
+    private int coolingTime = 0;
+
+    public CoolingLavaBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
+        super(type, pos, blockState);
+    }
+
+    public static void coolingLavaTick(Level level, BlockPos pos, BlockState state, CoolingLavaBlockEntity lava) {
+        lava.tick(level,pos,state);
+    }
+
+    private void tick(Level tickLevel,BlockPos pos, BlockState state){
+        if (coolingTime < 200) coolingTime++;
+        else if (!tickLevel.isClientSide)
+            level.setBlock(pos, Blocks.AIR.defaultBlockState(),3);
+    }
+
+
+}

--- a/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
+++ b/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
@@ -2,7 +2,6 @@ package net.tropicraft.core.common.block.tileentity;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
@@ -11,6 +10,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -84,9 +84,12 @@ public class VolcanoBlockEntity extends BlockEntity {
                 break;
 
             case ERUPTING:
-                if (!level.isClientSide) {
-                    if (level.random.nextInt(15) == 0)
+                if (level.random.nextInt(15) == 0) {
+                    if (!level.isClientSide)
                         throwLavaFromCaldera(4);
+                    level.playLocalSound(worldPosition.getX(), lavaLevel, worldPosition.getZ(),
+                            SoundEvents.BASALT_FALL, SoundSource.WEATHER, 50.0F,
+                            level.random.nextFloat() / 4 + 0.825f, true);
                 }
                 break;
 
@@ -105,7 +108,7 @@ public class VolcanoBlockEntity extends BlockEntity {
                         raiseLavaLevels();
                     } else {
                         ticksUntilEruption = 0;
-                        level.playLocalSound(worldPosition.getX(), lavaLevel, worldPosition.getY(),
+                        level.playLocalSound(worldPosition.getX(), lavaLevel, worldPosition.getZ(),
                                 SoundEvents.GENERIC_EXPLODE.value(), SoundSource.WEATHER, 10000.0F,
                                 level.random.nextFloat() / 4 + 0.825f, false);
 
@@ -125,21 +128,6 @@ public class VolcanoBlockEntity extends BlockEntity {
 
             default:
                 break;
-        }
-    }
-
-    public void cleanUpFromEruption() {
-        int xPos = worldPosition.getX();
-        int zPos = worldPosition.getZ();
-
-        for (int x = xPos - (radius * 2); x < xPos + (radius * 2); x++) {
-            for (int z = zPos - (radius * 2); z < zPos + (radius * 2); z++) {
-                for (int y = LAVA_BASE_LEVEL + heightOffset; y < 140; y++) {
-                    BlockPos outBlockPos = new BlockPos(x, y, z);
-                    if (level.getBlockState(outBlockPos).is(Blocks.LAVA))
-                        level.setBlockAndUpdate(outBlockPos, Blocks.AIR.defaultBlockState());
-                }
-            }
         }
     }
 
@@ -179,13 +167,13 @@ public class VolcanoBlockEntity extends BlockEntity {
     private void raiseLavaLevels() {
         if (lavaLevel < MAX_LAVA_LEVEL_DURING_ERUPTION + heightOffset) {
             lavaLevel++;
-            setBlocksOnLavaLevel(Blocks.LAVA.defaultBlockState(), 3);
+            setBlocksOnLavaLevel(Blocks.LAVA.defaultBlockState(), Block.UPDATE_ALL);
         }
     }
 
     private void lowerLavaLevels() {
         if (lavaLevel > LAVA_BASE_LEVEL + heightOffset) {
-            setBlocksOnLavaLevel(Blocks.AIR.defaultBlockState(), 3);
+            setBlocksOnLavaLevel(Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
             lavaLevel--;
         }
     }
@@ -215,10 +203,10 @@ public class VolcanoBlockEntity extends BlockEntity {
     }
 
     public void spewSmoke() {
-            double x = worldPosition.getX() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
-            double y = lavaLevel + level.random.nextInt(6);
-            double z = worldPosition.getZ() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
-            level.addParticle(TropicraftParticles.VOLCANO_SMOKE_PARTICLE.get(), true, x, y, z, 0.0, 0.7, 0.0);
+        double x = worldPosition.getX() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
+        double y = lavaLevel + level.random.nextInt(6);
+        double z = worldPosition.getZ() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
+        level.addParticle(TropicraftParticles.VOLCANO_SMOKE_PARTICLE.get(), true, x, y, z, 0.0, 0.7, 0.0);
     }
 
     private void updateStates() {

--- a/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
+++ b/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
@@ -60,7 +60,7 @@ public class VolcanoBlockEntity extends BlockEntity {
     }
 
     private void tick() {
-        if (!TropicsConfigs.allowVolcanoEruption) {
+        if (!TropicsConfigs.COMMON.allowVolcanoEruption.get()){
             return;
         }
 

--- a/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
+++ b/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
@@ -21,6 +21,7 @@ import net.tropicraft.core.common.block.TropicraftBlocks;
 import net.tropicraft.core.common.dimension.feature.volcano.VolcanoStructurePiece;
 import net.tropicraft.core.common.entity.TropicraftEntities;
 import net.tropicraft.core.common.entity.projectile.LavaBallEntity;
+import net.tropicraft.core.common.particle.TropicraftParticles;
 import net.tropicraft.core.common.volcano.VolcanoState;
 
 import javax.annotation.Nullable;
@@ -219,7 +220,7 @@ public class VolcanoBlockEntity extends BlockEntity {
             double x = worldPosition.getX() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
             double y = lavaLevel + level.random.nextInt(6);
             double z = worldPosition.getZ() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
-            level.addParticle(ParticleTypes.LARGE_SMOKE, true, x, y, z, 0.0, 0.7, 0.0);
+            level.addParticle(TropicraftParticles.VOLCANO_SMOKE_PARTICLE.get(), true, x, y, z, 0.0, 0.7, 0.0);
         }
     }
 

--- a/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
+++ b/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
@@ -9,6 +9,7 @@ import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.FluidTags;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -29,7 +30,6 @@ public class VolcanoBlockEntity extends BlockEntity {
     private static final int MAX_LAVA_LEVEL_DURING_RISE = VolcanoStructurePiece.VOLCANO_CRUST - 1;
     private static final int MAX_LAVA_LEVEL_DURING_ERUPTION = VolcanoStructurePiece.VOLCANO_CRUST + 1;
     private static final int LAVA_BASE_LEVEL = VolcanoStructurePiece.LAVA_LEVEL;
-    private static final int LAVA_ERUPT_LEVEL = VolcanoStructurePiece.LAVA_LEVEL + 11;
 
     private int ticksUntilEruption = VolcanoState.getTimeBefore(VolcanoState.ERUPTING);
     private int ticksUntilSmoking = VolcanoState.getTimeBefore(VolcanoState.SMOKING);
@@ -63,11 +63,6 @@ public class VolcanoBlockEntity extends BlockEntity {
             return;
         }
 
-        if (!getLevel().isClientSide) {
-            //System.out.println(radius + " Volcano Update: " + pos.getX() + " " + pos.getZ() + " State:" + state + " lvl: " + lavaLevel);
-            //System.out.println("smoking: " + ticksUntilSmoking + " rising: " + ticksUntilRising + " eruption: " + ticksUntilEruption + " retreating: " + ticksUntilRetreating + " dormant: " + ticksUntilDormant);
-        }
-
         // If radius needs to be initialized
         if (radius == -1) {
             radius = findRadius();
@@ -86,28 +81,21 @@ public class VolcanoBlockEntity extends BlockEntity {
         switch (state) {
             case DORMANT:
                 break;
-            case ERUPTING:
-                if (!getLevel().isClientSide) {
-                    //	if ((ticksUntilRetreating % (getWorld().rand.nextInt(40) + 10) == 0)/* && time > 800 && !falling*/) {
-                    if (getLevel().random.nextInt(15) == 0) {
-                        throwLavaFromCaldera(0.05 + Math.abs(getLevel().random.nextGaussian()) * (lavaLevel > 90 ? LAVA_ERUPT_LEVEL + heightOffset : 0.75));
-                    }
-                    //	}
 
-                    //	if ((ticksUntilRetreating % (getWorld().rand.nextInt(40) + 10) == 0) && lavaLevel > 90) {
-                    if (getLevel().random.nextInt(15) == 0) {
-                        throwLavaFromCaldera(0.05 + Math.abs(getLevel().random.nextGaussian()) * (lavaLevel > LAVA_ERUPT_LEVEL + heightOffset ? 1 : 0.75));
-                    }
-                    //	}
+            case ERUPTING:
+                if (!level.isClientSide) {
+                    if (level.random.nextInt(15) == 0)
+                        throwLavaFromCaldera(4);
                 }
                 break;
+
             case RETREATING:
-                if (ticksUntilDormant % 30 == 0) {
+                if (ticksUntilDormant % 30 == 0)
                     lowerLavaLevels();
-                }
                 break;
+
             case RISING:
-                if (getLevel().isClientSide) {
+                if (level.isClientSide) {
                     spewSmoke();
                 }
 
@@ -116,25 +104,24 @@ public class VolcanoBlockEntity extends BlockEntity {
                         raiseLavaLevels();
                     } else {
                         ticksUntilEruption = 0;
-                        getLevel().playLocalSound(worldPosition.getX(), 73, worldPosition.getY(), SoundEvents.GENERIC_EXPLODE.value(), SoundSource.NEUTRAL, 1.0f, getLevel().random.nextFloat() / 4 + 0.825f, false);
-                        int balls = getLevel().random.nextInt(25) + 15;
+                        level.playLocalSound(worldPosition.getX(), lavaLevel, worldPosition.getY(),
+                                SoundEvents.GENERIC_EXPLODE.value(), SoundSource.WEATHER, 10000.0F,
+                                level.random.nextFloat() / 4 + 0.825f, false);
 
+                        int balls = level.random.nextInt(25) + 15;
                         for (int i = 0; i < balls; i++) {
-                            throwLavaFromCaldera((getLevel().random.nextDouble() * 0.5) + 1.25);
+                            throwLavaFromCaldera(4);
                         }
                         break;
                     }
                 }
                 break;
+
             case SMOKING:
-                // TODO: Client only in the future if this is particles
-                if (getLevel().isClientSide) {
-                    //if (ticksUntilRising % 100 == 0) {
-                    //if (getWorld().rand.nextInt(10) == 0)
+                if (level.isClientSide)
                     spewSmoke();
-                    //}
-                }
                 break;
+
             default:
                 break;
         }
@@ -148,31 +135,44 @@ public class VolcanoBlockEntity extends BlockEntity {
             for (int z = zPos - (radius * 2); z < zPos + (radius * 2); z++) {
                 for (int y = LAVA_BASE_LEVEL + heightOffset; y < 140; y++) {
                     BlockPos outBlockPos = new BlockPos(x, y, z);
-                    if (getLevel().getBlockState(outBlockPos).is(Blocks.LAVA)) {
-                        getLevel().setBlockAndUpdate(outBlockPos, Blocks.AIR.defaultBlockState());
-                    }
+                    if (level.getBlockState(outBlockPos).is(Blocks.LAVA))
+                        level.setBlockAndUpdate(outBlockPos, Blocks.AIR.defaultBlockState());
                 }
             }
         }
     }
 
     public void throwLavaFromCaldera(double force) {
-        // Create vector at center facing in the +x direction
-        Vec3 pos = new Vec3(((getLevel().random.nextDouble() / 2) + 0.3) * radius, lavaLevel + 2, 0);
         // Get a random angle from 0 to 2PI (radians)
-        float angle = getLevel().random.nextFloat() * (float) Math.PI * 2;
-        // Rotate the center vector to this angle, and offset it to the volcano's position
-        pos = pos.yRot(angle).add(Vec3.atCenterOf(getBlockPos()));
-        // Compute x/y components of angle
-        double motX = force * Math.cos(angle);
-        double motZ = force * Math.sin(-angle);
-        throwLava(pos.x, pos.y, pos.z, motX, 0.86, motZ);
+        float facingAngle = level.random.nextFloat() * (float) Math.TAU;
+        // Get a random angle between 5 and 30 degrees
+        float pitchAngle = (5 + (level.random.nextFloat() * 25)) * Mth.DEG_TO_RAD;
+
+        Vec3 vec = new Vec3(0, 1, 0) // Create a unit vector facing up
+                .xRot(pitchAngle) // lean it by the pitchAngle
+                .yRot(facingAngle); // and rotate by the facingAngle
+
+        // Get the ball's deltaMovement by scaling the unit vector by force
+        Vec3 motion = vec.normalize().scale(force);
+
+        var center = worldPosition.getCenter();
+        var volcanoCenter = new Vec3(center.x, lavaLevel + 2, center.z);
+        Vec3 offset = vec.multiply(1, 0, 1).normalize() // flatten unit vector
+                .scale(radius / 2f) // scale it by size of volcano
+                .add(volcanoCenter); // offset the volcanoCenter by it
+
+        throwLava(offset, motion);
     }
 
-    public void throwLava(double i, double j, double k, double xMot, double yMot, double zMot) {
-        if (!getLevel().isClientSide) {
-            getLevel().addFreshEntity(new LavaBallEntity(TropicraftEntities.LAVA_BALL.get(), getLevel(), i, j, k, xMot, yMot, zMot));
-        }
+
+    public void throwLava(Vec3 pos, Vec3 deltaMovement) {
+        throwLava(pos.x, pos.y, pos.z, deltaMovement.x, deltaMovement.y, deltaMovement.z);
+    }
+
+    public void throwLava(double posX, double posY, double posZ, double xMot, double yMot, double zMot) {
+        if (!level.isClientSide)
+            level.addFreshEntity(new LavaBallEntity(TropicraftEntities.LAVA_BALL.get(), level, posX, posY, posZ, xMot
+                    , yMot, zMot));
     }
 
     private void raiseLavaLevels() {
@@ -197,38 +197,29 @@ public class VolcanoBlockEntity extends BlockEntity {
             for (int z = zPos - radius; z < zPos + radius; z++) {
                 if (Math.sqrt(Math.pow(x - xPos, 2) + Math.pow(z - zPos, 2)) < radius + 3) {
                     BlockPos botPos = new BlockPos(x, 10, z);
-                    if (getLevel().getBlockState(botPos).is(Blocks.LAVA)) {
+                    if (level.getBlockState(botPos).is(Blocks.LAVA)) {
                         BlockPos pos2 = new BlockPos(x, lavaLevel, z);
 
                         if (lavaLevel >= MAX_LAVA_LEVEL_DURING_RISE + heightOffset && lavaLevel < MAX_LAVA_LEVEL_DURING_ERUPTION + heightOffset) {
-                            if (getLevel().getBlockState(pos2).getBlock() != TropicraftBlocks.CHUNK.get()) {
-                                getLevel().setBlock(pos2, state, updateFlag);
+                            if (level.getBlockState(pos2).getBlock() != TropicraftBlocks.CHUNK.get()) {
+                                level.setBlock(pos2, state, updateFlag);
                             }
                         } else {
-                            getLevel().setBlock(pos2, state, updateFlag);
-                            // System.out.println("Setting block " + x + " " + lavaLevel + " " + z + " to whatever");
+                            level.setBlock(pos2, state, updateFlag);
                         }
-                        //getWorld().setBlockWithNotify(x, lavaLevel, z, falling ? 0 : lavaLevel >= 95 ? TropicraftMod.tempLavaMoving.blockID : Block.lavaStill.blockID);
                     }
                 }
             }
         }
-
-        //		if (updateFlag == 0) {
-        //			getWorld().markBlockRangeForRenderUpdate(xPos - radius, lavaLevel, zPos - radius, xPos + radius, lavaLevel, zPos + radius);
-        //		}
     }
 
     public void spewSmoke() {
-        // System.out.println("Spewing smoke");
-        int n = getLevel().random.nextInt(100) + 4;
+        int n = level.random.nextInt(100) + 4;
         for (int i = 0; i < n; i++) {
-            // getWorld().spawnEntity(new EntitySmoke(getWorld(), xPos + rand.nextInt(10) - 5, lavaLevel + rand.nextInt(4), zPos + rand.nextInt(10) - 5));
-            double x = worldPosition.getX() + getLevel().random.nextInt(radius) * (getLevel().random.nextBoolean() ? -1 : 1);
-            double y = lavaLevel + getLevel().random.nextInt(6);
-            double z = worldPosition.getZ() + getLevel().random.nextInt(radius) * (getLevel().random.nextBoolean() ? -1 : 1);
-            getLevel().addParticle(ParticleTypes.LARGE_SMOKE, true, x, y, z, 0.0, 0.7, 0.0);
-            //System.out.println("Spewing smoke " + x + " " + z);
+            double x = worldPosition.getX() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
+            double y = lavaLevel + level.random.nextInt(6);
+            double z = worldPosition.getZ() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
+            level.addParticle(ParticleTypes.LARGE_SMOKE, true, x, y, z, 0.0, 0.7, 0.0);
         }
     }
 
@@ -280,9 +271,9 @@ public class VolcanoBlockEntity extends BlockEntity {
 
                 // If it's time to go to sleep, then let's do it
                 if (ticksUntilDormant <= 0) {
-                    // cleanUpFromEruption();
                     state = VolcanoState.DORMANT;
-                    ticksUntilDormant = VolcanoState.getTimeBefore(VolcanoState.DORMANT) + getLevel().random.nextInt(RAND_DORMANT_DURATION);
+                    ticksUntilDormant =
+                            VolcanoState.getTimeBefore(VolcanoState.DORMANT) + level.random.nextInt(RAND_DORMANT_DURATION);
                 }
                 break;
             default:

--- a/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
+++ b/src/main/java/net/tropicraft/core/common/block/tileentity/VolcanoBlockEntity.java
@@ -100,7 +100,7 @@ public class VolcanoBlockEntity extends BlockEntity {
                     spewSmoke();
                 }
 
-                if (ticksUntilEruption % 20 == 0) {
+                if (ticksUntilEruption >= 20 && ticksUntilEruption % 20 == 0) {
                     if (lavaLevel < MAX_LAVA_LEVEL_DURING_ERUPTION + heightOffset) {
                         raiseLavaLevels();
                     } else {
@@ -215,13 +215,10 @@ public class VolcanoBlockEntity extends BlockEntity {
     }
 
     public void spewSmoke() {
-        int n = level.random.nextInt(100) + 4;
-        for (int i = 0; i < n; i++) {
             double x = worldPosition.getX() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
             double y = lavaLevel + level.random.nextInt(6);
             double z = worldPosition.getZ() + level.random.nextInt(radius) * (level.random.nextBoolean() ? -1 : 1);
             level.addParticle(TropicraftParticles.VOLCANO_SMOKE_PARTICLE.get(), true, x, y, z, 0.0, 0.7, 0.0);
-        }
     }
 
     private void updateStates() {

--- a/src/main/java/net/tropicraft/core/common/dimension/feature/volcano/VolcanoStructurePiece.java
+++ b/src/main/java/net/tropicraft/core/common/dimension/feature/volcano/VolcanoStructurePiece.java
@@ -108,7 +108,7 @@ public class VolcanoStructurePiece extends StructurePiece {
 
         BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
 
-        for (int y = level.getMaxBuildHeight(); y > level.getMinBuildHeight(); y--) {
+        for (int y = level.getMaxBuildHeight(); y > level.getMinBuildHeight() + 2; y--) {
             mutablePos.set(x, y, z);
 
             if (height + terrainY < calderaCutoffY) {

--- a/src/main/java/net/tropicraft/core/common/entity/TropicraftEntities.java
+++ b/src/main/java/net/tropicraft/core/common/entity/TropicraftEntities.java
@@ -170,8 +170,18 @@ public class TropicraftEntities {
                     .setShouldReceiveVelocityUpdates(false))
             .renderer(() -> BambooItemFrameRenderer::new)
             .register();
-    // TODO: Register again when volcano eruption is finished
-    public static final EntityEntry<LavaBallEntity> LAVA_BALL = null;//register("lava_ball", TropicraftEntities::lavaBall);
+
+    public static final EntityEntry<LavaBallEntity> LAVA_BALL =  REGISTRATE.entity("lava_ball",
+                    (EntityType.EntityFactory<LavaBallEntity>)
+                    LavaBallEntity::new,
+            MobCategory.MISC)
+            .properties(b -> b.sized(1f, 1f)
+                    .setTrackingRange(8)
+                    .setUpdateInterval(3)
+                    .setShouldReceiveVelocityUpdates(true))
+            .renderer(() -> LavaBallRenderer::new)
+            .register();
+
     public static final EntityEntry<SeaTurtleEntity> SEA_TURTLE = REGISTRATE.entity("turtle", SeaTurtleEntity::new, MobCategory.WATER_CREATURE)
             .properties(b -> b.sized(0.8f, 0.35f)
                     .setTrackingRange(8)
@@ -555,14 +565,6 @@ public class TropicraftEntities {
                     .setShouldReceiveVelocityUpdates(true))
             .renderer(() -> SpearRenderer::new)
             .register();
-
-    //    private static void lavaBall(EntityType.Builder<LavaBallEntity> b) {
-//        return EntityType.Builder.<LavaBallEntity>of(LavaBallEntity::new, MobCategory.MISC)
-//                .sized(1.0f, 1.0f)
-//                .setTrackingRange(8)
-//                .setUpdateInterval(3)
-//                .setShouldReceiveVelocityUpdates(true);
-//    }
 
     public static final RegistryEntry<EntityType<?>, EntityType<GibnutEntity>> GIBNUT = REGISTRATE.entity("gibnut", GibnutEntity::new, MobCategory.MONSTER)
             .properties(b -> b.sized(0.7f, 0.3f)

--- a/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
@@ -5,10 +5,12 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
@@ -111,6 +113,7 @@ public class LavaBallEntity extends Entity {
         if (!level().isClientSide) {
             BlockPos posCurrent = this.blockPosition();
             if (maybeReplace(posCurrent)) {
+                playSound(SoundEvents.BUCKET_EMPTY_LAVA, 5.0F, random.nextFloat() / 4 + 0.425f);
                 for (var dir : PLACEMENT_DIRECTIONS)
                     maybeReplace(posCurrent.relative(dir));
                 remove(RemovalReason.DISCARDED);
@@ -132,7 +135,7 @@ public class LavaBallEntity extends Entity {
         BlockState stateBelow = level().getBlockState(posBelow);
         if (!stateBelow.isEmpty() && !held) {
             if (stateCurrent.isEmpty() || stateCurrent.is(BlockTags.REPLACEABLE)) {
-                level().setBlock(pos, TropicraftBlocks.COOLING_LAVA.get().defaultBlockState(), 3);
+                level().setBlock(pos, TropicraftBlocks.COOLING_LAVA.get().defaultBlockState(), Block.UPDATE_ALL);
                 return true;
             }
         }

--- a/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
@@ -6,7 +6,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -15,16 +14,12 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 
 public class LavaBallEntity extends Entity {
+    public final boolean held;
     public boolean setFire;
     public float size;
-    public final boolean held;
     public int lifeTimer;
 
-    public double accelerationX;
-    public double accelerationY;
-    public double accelerationZ;
-
-    public LavaBallEntity(EntityType<? extends LavaBallEntity> type, Level world) {
+    public LavaBallEntity(EntityType<? extends Entity> type, Level world) {
         super(type, world);
         setFire = false;
         held = false;
@@ -32,24 +27,15 @@ public class LavaBallEntity extends Entity {
         lifeTimer = 0;
     }
 
-    public LavaBallEntity(EntityType<? extends LavaBallEntity> type, Level world, double i, double j, double k, double motX, double motY, double motZ) {
-        super(type, world);
-        setFire = false;
-        moveTo(i, j, k, 0, 0);
-        accelerationX = motX;
-        accelerationY = motY;
-        accelerationZ = motZ;
-        size = 1;
-        held = false;
-        lifeTimer = 0;
+    public LavaBallEntity(EntityType<? extends LavaBallEntity> type, Level world, double x, double y, double z,
+                          double motX, double motY, double motZ) {
+        this(type,world);
+        moveTo(x, y, z, 0, 0);
+        setDeltaMovement(motX, motY, motZ);
     }
 
-    public LavaBallEntity(EntityType<? extends LavaBallEntity> type, Level world, float startSize) {
-        super(type, world);
-        size = startSize;
-        setFire = false;
-        held = true;
-        lifeTimer = 0;
+    public LavaBallEntity(EntityType<? extends LavaBallEntity> type, Level world, Vec3 pos, Vec3 deltaMovement) {
+        this(type, world, pos.x, pos.y, pos.z, deltaMovement.x, deltaMovement.y, deltaMovement.z);
     }
 
     @Override
@@ -80,31 +66,23 @@ public class LavaBallEntity extends Entity {
     @Override
     public void tick() {
         super.tick();
-        // System.out.println("laba ball: " + posX + " " + posY + " " + posZ);
-
         if (lifeTimer < 500) {
             lifeTimer++;
         } else {
             remove(RemovalReason.DISCARDED);
         }
 
-        double motionX = getDeltaMovement().x;
-        double motionY = getDeltaMovement().y;
-        double motionZ = getDeltaMovement().z;
+        var delta = getDeltaMovement();
+
+        double newX = getX() + delta.x;
+        double newY = getY() + delta.y;
+        double newZ = getZ() + delta.z;
 
         if (size < 1) {
             size += 0.025;
         }
 
-        if (onGround()) {
-            motionZ *= 0.95;
-            motionX *= 0.95;
-        }
-
-        motionY *= 0.99;
-
         if (!onGround()) {
-            motionY -= 0.05f;
             if (level().isClientSide) {
                 for (int i = 0; i < 5 + random.nextInt(3); i++) {
                     supahDrip();
@@ -112,17 +90,7 @@ public class LavaBallEntity extends Entity {
             }
         }
 
-        if (horizontalCollision) {
-            motionZ = 0;
-            motionX = 0;
-        }
-
-        //TODO: Note below, these used to be tempLavaMoving - maybe they still need to be?
-        int thisX = (int) Math.floor(getX());
-        int thisY = (int) Math.floor(getY());
-        int thisZ = (int) Math.floor(getZ());
-
-        BlockPos posCurrent = new BlockPos(thisX, thisY, thisZ);
+        BlockPos posCurrent = this.blockPosition();
         BlockPos posBelow = posCurrent.below();
         BlockState stateBelow = level().getBlockState(posBelow);
 
@@ -134,19 +102,19 @@ public class LavaBallEntity extends Entity {
 
             if (!setFire) {
                 if (level().isEmptyBlock(posCurrent.west())) {
-                    level().setBlock(posCurrent.west(), Blocks.LAVA.defaultBlockState(), 2);
+                    level().setBlock(posCurrent.west(), Blocks.LAVA.defaultBlockState(), 3);
                 }
 
                 if (level().isEmptyBlock(posCurrent.east())) {
-                    level().setBlock(posCurrent.east(), Blocks.LAVA.defaultBlockState(), 2);
+                    level().setBlock(posCurrent.east(), Blocks.LAVA.defaultBlockState(), 3);
                 }
 
                 if (level().isEmptyBlock(posCurrent.south())) {
-                    level().setBlock(posCurrent.south(), Blocks.LAVA.defaultBlockState(), 2);
+                    level().setBlock(posCurrent.south(), Blocks.LAVA.defaultBlockState(), 3);
                 }
 
                 if (level().isEmptyBlock(posCurrent.north())) {
-                    level().setBlock(posCurrent.north(), Blocks.LAVA.defaultBlockState(), 2);
+                    level().setBlock(posCurrent.north(), Blocks.LAVA.defaultBlockState(), 3);
                 }
 
                 level().setBlock(posCurrent, Blocks.LAVA.defaultBlockState(), 3);
@@ -154,19 +122,25 @@ public class LavaBallEntity extends Entity {
             }
         }
 
-        Vec3 motion = new Vec3(motionX + accelerationX, motionY + accelerationY, motionZ + accelerationZ);
-        setDeltaMovement(motion);
+        //Vec3 motion = new Vec3(motionX + accelerationX, motionY + accelerationY, motionZ + accelerationZ);
+        setDeltaMovement(delta.scale(0.999));
 
-        move(MoverType.SELF, motion);
+        this.applyGravity();
+        this.setPos(newX, newY, newZ);
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag nbt) {
+    protected double getDefaultGravity() {
+        return 0;
+    }
+
+    @Override
+    public void readAdditionalSaveData(CompoundTag nbt) {
         lifeTimer = nbt.getInt("lifeTimer");
     }
 
     @Override
-    protected void addAdditionalSaveData(CompoundTag nbt) {
+    public void addAdditionalSaveData(CompoundTag nbt) {
         nbt.putInt("lifeTimer", lifeTimer);
     }
 }

--- a/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
@@ -104,10 +104,9 @@ public class LavaBallEntity extends Entity {
         }
 
         this.moveTo(new Vec3(newX, newY, newZ));
-        this.tryCheckInsideBlocks();
         setDeltaMovement(new Vec3(deltaX, deltaY, deltaZ).scale(0.999));
         this.applyGravity();
-
+        this.tryCheckInsideBlocks();
 
         if (!level().isClientSide) {
             BlockPos posCurrent = this.blockPosition();
@@ -122,8 +121,8 @@ public class LavaBallEntity extends Entity {
     @Override
     protected void onInsideBlock(BlockState blockstate) {
         if (!blockstate.isEmpty() && !blockstate.is(TropicraftBlocks.COOLING_LAVA)) {
-            setPos(blockPosition().above().getBottomCenter());
             setDeltaMovement(Vec3.ZERO);
+            setPos(blockPosition().above().getBottomCenter());
         }
     }
 

--- a/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
@@ -1,28 +1,32 @@
 package net.tropicraft.core.common.entity.projectile;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.tropicraft.core.common.block.TropicraftBlocks;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class LavaBallEntity extends Entity {
+    private static final List<Direction> PLACEMENT_DIRECTIONS = Arrays.asList(Direction.NORTH, Direction.SOUTH,
+            Direction.EAST, Direction.WEST);
     public final boolean held;
-    public boolean setFire;
     public float size;
     public int lifeTimer;
 
     public LavaBallEntity(EntityType<? extends Entity> type, Level world) {
         super(type, world);
-        setFire = false;
         held = false;
         size = 1;
         lifeTimer = 0;
@@ -67,49 +71,78 @@ public class LavaBallEntity extends Entity {
     @Override
     public void tick() {
         super.tick();
-        if (lifeTimer < 500) {
+        if (lifeTimer < 500)
             lifeTimer++;
-        } else {
+        else
             remove(RemovalReason.DISCARDED);
+
+
+        if (size < 1)
+            size += 0.025F;
+
+        if (!onGround() && level().isClientSide) {
+            for (int i = 0; i < 1 + random.nextInt(3); i++)
+                supahDrip();
         }
 
         var delta = getDeltaMovement();
+        var deltaX = delta.x;
+        var deltaY = delta.y;
+        var deltaZ = delta.z;
 
-        double newX = getX() + delta.x;
-        double newY = getY() + delta.y;
-        double newZ = getZ() + delta.z;
-        this.setPos(newX, newY, newZ);
 
-        setDeltaMovement(delta.scale(0.999));
+        double newX = getX() + deltaX;
+        double newY = getY() + deltaY;
+        double newZ = getZ() + deltaZ;
+
+        if (horizontalCollision) {
+            deltaX = 0;
+            deltaZ = 0;
+        }
+        if (verticalCollision) {
+            deltaY = 0;
+        }
+
+        this.moveTo(new Vec3(newX, newY, newZ));
+        this.tryCheckInsideBlocks();
+        setDeltaMovement(new Vec3(deltaX, deltaY, deltaZ).scale(0.999));
         this.applyGravity();
 
-        if (size < 1) {
-            size += 0.025;
-        }
 
-        if (!onGround()) {
-            if (level().isClientSide) {
-                for (int i = 0; i < 1 + random.nextInt(3); i++) {
-                    supahDrip();
-                }
+        if (!level().isClientSide) {
+            BlockPos posCurrent = this.blockPosition();
+            if (maybeReplace(posCurrent)) {
+                for (var dir : PLACEMENT_DIRECTIONS)
+                    maybeReplace(posCurrent.relative(dir));
+                remove(RemovalReason.DISCARDED);
             }
-        }
-
-        BlockPos posCurrent = this.blockPosition();
-        BlockState stateCurrent = level().getBlockState(posCurrent);
-        BlockPos posBelow = posCurrent.below();
-        BlockState stateBelow = level().getBlockState(posBelow);
-
-        if (!stateBelow.isEmpty() && !held) {
-            if (stateCurrent.isEmpty())
-                level().setBlock(posCurrent, TropicraftBlocks.COOLING_LAVA.get().defaultBlockState(), 3);
-            remove(RemovalReason.DISCARDED);
         }
     }
 
     @Override
+    protected void onInsideBlock(BlockState blockstate) {
+        if (!blockstate.isEmpty() && !blockstate.is(TropicraftBlocks.COOLING_LAVA)) {
+            setPos(blockPosition().above().getBottomCenter());
+            setDeltaMovement(Vec3.ZERO);
+        }
+    }
+
+    private boolean maybeReplace(BlockPos pos) {
+        BlockState stateCurrent = level().getBlockState(pos);
+        BlockPos posBelow = pos.below();
+        BlockState stateBelow = level().getBlockState(posBelow);
+        if (!stateBelow.isEmpty() && !held) {
+            if (stateCurrent.isEmpty() || stateCurrent.is(BlockTags.REPLACEABLE)) {
+                level().setBlock(pos, TropicraftBlocks.COOLING_LAVA.get().defaultBlockState(), 3);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     protected double getDefaultGravity() {
-        return 0.15;
+        return 0.1;
     }
 
     @Override

--- a/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
@@ -109,7 +109,7 @@ public class LavaBallEntity extends Entity {
 
     @Override
     protected double getDefaultGravity() {
-        return 0;
+        return 0.15;
     }
 
     @Override

--- a/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
@@ -56,7 +56,7 @@ public class LavaBallEntity extends Entity {
         float z = (float) getZ();
 
         if (level().isClientSide) {
-            level().addParticle(ParticleTypes.LAVA, x, y, z, getDeltaMovement().x, -1.5f, getDeltaMovement().z);
+            level().addParticle(ParticleTypes.LAVA, x, y, z, -getDeltaMovement().x, -1.5f, -getDeltaMovement().z);
         }
     }
 

--- a/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
@@ -12,6 +12,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import net.tropicraft.core.common.block.TropicraftBlocks;
 
 public class LavaBallEntity extends Entity {
     public final boolean held;
@@ -29,7 +30,7 @@ public class LavaBallEntity extends Entity {
 
     public LavaBallEntity(EntityType<? extends LavaBallEntity> type, Level world, double x, double y, double z,
                           double motX, double motY, double motZ) {
-        this(type,world);
+        this(type, world);
         moveTo(x, y, z, 0, 0);
         setDeltaMovement(motX, motY, motZ);
     }
@@ -77,6 +78,10 @@ public class LavaBallEntity extends Entity {
         double newX = getX() + delta.x;
         double newY = getY() + delta.y;
         double newZ = getZ() + delta.z;
+        this.setPos(newX, newY, newZ);
+
+        setDeltaMovement(delta.scale(0.999));
+        this.applyGravity();
 
         if (size < 1) {
             size += 0.025;
@@ -91,42 +96,15 @@ public class LavaBallEntity extends Entity {
         }
 
         BlockPos posCurrent = this.blockPosition();
+        BlockState stateCurrent = level().getBlockState(posCurrent);
         BlockPos posBelow = posCurrent.below();
         BlockState stateBelow = level().getBlockState(posBelow);
 
-        if (!stateBelow.isAir() && !stateBelow.is(Blocks.LAVA) && !held) {
-            if (setFire) {
-                level().setBlock(posCurrent, Blocks.LAVA.defaultBlockState(), 3);
-                remove(RemovalReason.DISCARDED);
-            }
-
-            if (!setFire) {
-                if (level().isEmptyBlock(posCurrent.west())) {
-                    level().setBlock(posCurrent.west(), Blocks.LAVA.defaultBlockState(), 3);
-                }
-
-                if (level().isEmptyBlock(posCurrent.east())) {
-                    level().setBlock(posCurrent.east(), Blocks.LAVA.defaultBlockState(), 3);
-                }
-
-                if (level().isEmptyBlock(posCurrent.south())) {
-                    level().setBlock(posCurrent.south(), Blocks.LAVA.defaultBlockState(), 3);
-                }
-
-                if (level().isEmptyBlock(posCurrent.north())) {
-                    level().setBlock(posCurrent.north(), Blocks.LAVA.defaultBlockState(), 3);
-                }
-
-                level().setBlock(posCurrent, Blocks.LAVA.defaultBlockState(), 3);
-                setFire = true;
-            }
+        if (!stateBelow.isEmpty() && !held) {
+            if (stateCurrent.isEmpty())
+                level().setBlock(posCurrent, TropicraftBlocks.COOLING_LAVA.get().defaultBlockState(), 3);
+            remove(RemovalReason.DISCARDED);
         }
-
-        //Vec3 motion = new Vec3(motionX + accelerationX, motionY + accelerationY, motionZ + accelerationZ);
-        setDeltaMovement(delta.scale(0.999));
-
-        this.applyGravity();
-        this.setPos(newX, newY, newZ);
     }
 
     @Override

--- a/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
+++ b/src/main/java/net/tropicraft/core/common/entity/projectile/LavaBallEntity.java
@@ -89,7 +89,7 @@ public class LavaBallEntity extends Entity {
 
         if (!onGround()) {
             if (level().isClientSide) {
-                for (int i = 0; i < 5 + random.nextInt(3); i++) {
+                for (int i = 0; i < 1 + random.nextInt(3); i++) {
                     supahDrip();
                 }
             }

--- a/src/main/java/net/tropicraft/core/common/particle/TropicraftParticles.java
+++ b/src/main/java/net/tropicraft/core/common/particle/TropicraftParticles.java
@@ -1,0 +1,27 @@
+package net.tropicraft.core.common.particle;
+
+import net.minecraft.core.particles.ParticleType;
+import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Supplier;
+
+import static net.tropicraft.Tropicraft.ID;
+
+@EventBusSubscriber(modid = ID, bus = EventBusSubscriber.Bus.MOD)
+public final class TropicraftParticles {
+    public static final DeferredRegister<ParticleType<?>> PARTICLE_TYPES =
+            DeferredRegister.create(BuiltInRegistries.PARTICLE_TYPE, ID);
+
+    public static final Supplier<SimpleParticleType> VOLCANO_SMOKE_PARTICLE = PARTICLE_TYPES.register("volcano_smoke"
+            , () -> new SimpleParticleType(true));
+
+    @SubscribeEvent
+    public static void registerParticleProviders(RegisterParticleProvidersEvent event) {
+        event.registerSpriteSet(VOLCANO_SMOKE_PARTICLE.get(), VolcanoSmokeParticle.VolcanoProvider::new);
+    }
+}

--- a/src/main/java/net/tropicraft/core/common/particle/VolcanoSmokeParticle.java
+++ b/src/main/java/net/tropicraft/core/common/particle/VolcanoSmokeParticle.java
@@ -33,7 +33,7 @@ public class VolcanoSmokeParticle extends CampfireSmokeParticle {
             VolcanoSmokeParticle volcanoSmokeParticle = new VolcanoSmokeParticle(
                     level, x, y, z, xSpeed, ySpeed, zSpeed,true);
             volcanoSmokeParticle.setAlpha(0.9F);
-            volcanoSmokeParticle.scale(2f);
+            volcanoSmokeParticle.scale(12F);
             volcanoSmokeParticle.pickSprite(this.sprites);
             return volcanoSmokeParticle;
         }

--- a/src/main/java/net/tropicraft/core/common/particle/VolcanoSmokeParticle.java
+++ b/src/main/java/net/tropicraft/core/common/particle/VolcanoSmokeParticle.java
@@ -1,0 +1,41 @@
+package net.tropicraft.core.common.particle;
+
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.*;
+import net.minecraft.core.particles.SimpleParticleType;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+public class VolcanoSmokeParticle extends CampfireSmokeParticle {
+    protected VolcanoSmokeParticle(ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed,
+                                   double zSpeed,boolean signal) {
+        super(level, x, y, z, xSpeed, ySpeed, zSpeed, true);
+        hasPhysics = false;
+    }
+    @OnlyIn(Dist.CLIENT)
+    public static class VolcanoProvider implements ParticleProvider<SimpleParticleType> {
+        private final SpriteSet sprites;
+
+        public VolcanoProvider(SpriteSet sprites) {
+            this.sprites = sprites;
+        }
+
+        public Particle createParticle(
+                SimpleParticleType type,
+                ClientLevel level,
+                double x,
+                double y,
+                double z,
+                double xSpeed,
+                double ySpeed,
+                double zSpeed
+        ) {
+            VolcanoSmokeParticle volcanoSmokeParticle = new VolcanoSmokeParticle(
+                    level, x, y, z, xSpeed, ySpeed, zSpeed,true);
+            volcanoSmokeParticle.setAlpha(0.9F);
+            volcanoSmokeParticle.scale(2f);
+            volcanoSmokeParticle.pickSprite(this.sprites);
+            return volcanoSmokeParticle;
+        }
+    }
+}

--- a/src/main/resources/assets/tropicraft/particles/volcano_smoke.json
+++ b/src/main/resources/assets/tropicraft/particles/volcano_smoke.json
@@ -1,0 +1,16 @@
+{
+    "textures": [
+        "minecraft:big_smoke_0",
+        "minecraft:big_smoke_1",
+        "minecraft:big_smoke_2",
+        "minecraft:big_smoke_3",
+        "minecraft:big_smoke_4",
+        "minecraft:big_smoke_5",
+        "minecraft:big_smoke_6",
+        "minecraft:big_smoke_7",
+        "minecraft:big_smoke_8",
+        "minecraft:big_smoke_9",
+        "minecraft:big_smoke_10",
+        "minecraft:big_smoke_11"
+    ]
+}


### PR DESCRIPTION
This allows Tropicraft volcanoes to erupt again.

- Adds a simple model for lava balls
- Adds "cooling lava", a lava block with a ticker that removes itself when the ticker expires. This minimizes the damage to terrain from explosions while still starting fires and spewing flowing lava everywhere.
- Lava balls place cooling lava when they hit the ground.
- Changes the calculation for lava ball trajectories so that they don't frequenly collide with the edge of the caldera.
- Instead of spawning huge numbers of minecraft large smoke particles during the Smoking phase, spawns a smaller number of large particles based on vanilla campfire smoke.
- Changes the parameters for the inital eruption explosion sound to be more like vanilla thunder, so that it can be heard when you're not standing right next to to the volcano.
- Adds sound effects for lava balls launched after the initial explosion.
- Adds localized "splat" sound effects when lava balls hit the ground and place cooling lava.